### PR TITLE
Add support for tally on/off

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -20,9 +20,9 @@ Zoom In, Zoom Out, Zoom Speed Up, Zoom Speed Down, Focus Far, Focus Near, Focus 
 
 Set Iris, Iris Open, Iris Close, Set Gain, Gain Up, Gain Down, Set Shutter, Shutter Up, Shutter Down, Set Filter, Filter Up, Filter Down, Set Pedestal, Pedestal Up, Pedestal Down
 
-*Power*
+*Power/Tally*
 
-Power Off, Power On
+Power Off, Power On, Tally Off, Tally On
 
 *Save presets*
 

--- a/index.js
+++ b/index.js
@@ -204,9 +204,9 @@ instance.prototype.tallyOnListener = function (label, variable, value) {
 		return;
 	}
 
-	system.emit('variable_parse', tallyOnValue, (parsedValue) => {
+	self.system.emit('variable_parse', tallyOnValue, (parsedValue) => {
 		debug('variable changed... updating tally', { label, variable, value, parsedValue });
-		system.emit('action_run', {
+		self.system.emit('action_run', {
 			action: (value === parsedValue ? 'tallyOn' : 'tallyOff'),
 			instance: self.id
 		});
@@ -267,7 +267,7 @@ instance.prototype.config_fields = function () {
 	var self = this;
 
 	const dynamicVariableChoices = [];
-	system.emit('variable_get_definitions', (definitions) =>
+	self.system.emit('variable_get_definitions', (definitions) =>
 		Object.entries(definitions).forEach(([instanceLabel, variables]) =>
 			variables.forEach((variable) =>
 				dynamicVariableChoices.push({

--- a/index.js
+++ b/index.js
@@ -266,6 +266,18 @@ instance.prototype.updateConfig = function(config) {
 instance.prototype.config_fields = function () {
 	var self = this;
 
+  const dynamicVariableChoices = [];
+  system.emit('variable_get_definitions', (definitions) =>
+		Object.entries(definitions).forEach(([instanceLabel, variables]) =>
+			variables.forEach((variable) =>
+				dynamicVariableChoices.push({
+				  id: `${instanceLabel}:${variable.name}`,
+					label: `${instanceLabel}:${variable.name}`
+				})
+			)
+		)
+  );
+
 	return [
 		{
 			type: 'text',
@@ -289,11 +301,13 @@ instance.prototype.config_fields = function () {
 			value: 'Set camera tally ON when the instance variable equals the value'
 		},
 		{
-			type: 'textinput',
+			type: 'dropdown',
 			id: 'tallyOnVariable',
 			label: 'Tally On Variable',
 			width: 6,
-			tooltip: 'The instance label and variable name.  For example, atem:pgm1_input'
+			tooltip: 'The instance label and variable name',
+			choices: dynamicVariableChoices,
+			minChoicesForSearch: 5
 		},
 		{
 			type: 'textinput',

--- a/index.js
+++ b/index.js
@@ -828,7 +828,7 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Power',
+			category: 'Power/Tally',
 			label: 'Power Off',
 			bank: {
 				style: 'text',
@@ -844,7 +844,7 @@ instance.prototype.init_presets = function () {
 			]
 		},
 		{
-			category: 'Power',
+			category: 'Power/Tally',
 			label: 'Power On',
 			bank: {
 				style: 'text',
@@ -856,6 +856,38 @@ instance.prototype.init_presets = function () {
 			actions: [
 				{
 					action: 'powerOn',
+				}
+			]
+		},
+		{
+			category: 'Power/Tally',
+			label: 'Tally Off',
+			bank: {
+				style: 'text',
+				text: 'Tally\\nOff',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0),
+			},
+			actions: [
+				{
+					action: 'tallyOff',
+				}
+			]
+		},
+		{
+			category: 'Power/Tally',
+			label: 'Tally On',
+			bank: {
+				style: 'text',
+				text: 'Tally\\nOn',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0),
+			},
+			actions: [
+				{
+					action: 'tallyOn',
 				}
 			]
 		},
@@ -964,6 +996,8 @@ instance.prototype.actions = function(system) {
 		},
 		'ptSpeedU':       { label: 'P/T Speed Up'},
 		'ptSpeedD':       { label: 'P/T Speed Down'},
+		'tallyOff':       { label: 'Tally Off' },
+		'tallyOn':        { label: 'Tally On' },
 		'zoomI':          { label: 'Zoom In' },
 		'zoomO':          { label: 'Zoom Out' },
 		'zoomS':          { label: 'Zoom Stop' },
@@ -1232,6 +1266,16 @@ instance.prototype.action = function(action) {
 			}
 			self.ptSpeed = SPEED[self.ptSpeedIndex].id
 			self.setVariable('ptSpeedVar', self.ptSpeed);
+			break;
+
+		case 'tallyOff':
+			cmd = 'DA0';
+			self.sendPTZ(cmd);
+			break;
+
+		case 'tallyOn':
+			cmd = 'DA1';
+			self.sendPTZ(cmd);
 			break;
 
 		case 'zoomO':

--- a/index.js
+++ b/index.js
@@ -306,6 +306,10 @@ instance.prototype.config_fields = function () {
 // When module gets deleted
 instance.prototype.destroy = function() {
 	var self = this;
+	if (self.activeTallyOnListener) {
+		self.system.removeListener('variable_changed', self.activeTallyOnListener);
+		self.activeTallyOnListener = undefined;
+	}
 }
 
 instance.prototype.init_presets = function () {

--- a/index.js
+++ b/index.js
@@ -204,10 +204,12 @@ instance.prototype.tallyOnListener = function (label, variable, value) {
 		return;
 	}
 
-	debug('variable changed... updating tally', { label, variable, value });
-	system.emit('action_run', {
-		action: (value === tallyOnValue ? 'tallyOn' : 'tallyOff'),
-		instance: self.id
+	system.emit('variable_parse', tallyOnValue, (parsedValue) => {
+		debug('variable changed... updating tally', { label, variable, value, parsedValue });
+		system.emit('action_run', {
+			action: (value === parsedValue ? 'tallyOn' : 'tallyOff'),
+			instance: self.id
+		});
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -266,17 +266,17 @@ instance.prototype.updateConfig = function(config) {
 instance.prototype.config_fields = function () {
 	var self = this;
 
-  const dynamicVariableChoices = [];
-  system.emit('variable_get_definitions', (definitions) =>
+	const dynamicVariableChoices = [];
+	system.emit('variable_get_definitions', (definitions) =>
 		Object.entries(definitions).forEach(([instanceLabel, variables]) =>
 			variables.forEach((variable) =>
 				dynamicVariableChoices.push({
-				  id: `${instanceLabel}:${variable.name}`,
+					id: `${instanceLabel}:${variable.name}`,
 					label: `${instanceLabel}:${variable.name}`
 				})
 			)
 		)
-  );
+	);
 
 	return [
 		{

--- a/index.js
+++ b/index.js
@@ -198,9 +198,9 @@ function instance(system, id, config) {
 
 instance.prototype.tallyOnListener = function (label, variable, value) {
 	const self = this;
-	const { tallyOnVariable, tallyOnValue } = self.config;
+	const { tallyOnEnabled, tallyOnVariable, tallyOnValue } = self.config;
 
-	if (`${label}:${variable}` !== tallyOnVariable) {
+	if (!tallyOnEnabled || `${label}:${variable}` !== tallyOnVariable) {
 		return;
 	}
 
@@ -216,14 +216,14 @@ instance.prototype.tallyOnListener = function (label, variable, value) {
 instance.prototype.setupEventListeners = function () {
 	const self = this;
 
-	if (self.config.tallyOnVariable) {
+	if (self.config.tallyOnEnabled && self.config.tallyOnVariable) {
 		if (!self.activeTallyOnListener) {
 			self.activeTallyOnListener = self.tallyOnListener.bind(self);
 			self.system.on('variable_changed', self.activeTallyOnListener);
 		}
 	} else if (self.activeTallyOnListener) {
 		self.system.removeListener('variable_changed', self.activeTallyOnListener);
-		self.activeTallyOnListener = undefined;
+		delete self.activeTallyOnListener;
 	}
 }
 
@@ -301,6 +301,13 @@ instance.prototype.config_fields = function () {
 			value: 'Set camera tally ON when the instance variable equals the value'
 		},
 		{
+			type: 'checkbox',
+			id: 'tallyOnEnabled',
+			width: 1,
+			label: 'Enable',
+			default: true
+		},
+		{
 			type: 'dropdown',
 			id: 'tallyOnVariable',
 			label: 'Tally On Variable',
@@ -313,7 +320,7 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'tallyOnValue',
 			label: 'Tally On Value',
-			width: 6,
+			width: 5,
 			tooltip: 'When the variable equals this value, the camera tally light will be turned on'
 		}
 	]
@@ -324,7 +331,7 @@ instance.prototype.destroy = function() {
 	var self = this;
 	if (self.activeTallyOnListener) {
 		self.system.removeListener('variable_changed', self.activeTallyOnListener);
-		self.activeTallyOnListener = undefined;
+		delete self.activeTallyOnListener;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ instance.prototype.config_fields = function () {
 			id: 'tallyOnValue',
 			label: 'Tally On Value',
 			width: 5,
-			tooltip: 'When the variable equals this value, the camera tally light will be turned on'
+			tooltip: 'When the variable equals this value, the camera tally light will be turned on.  Also supports dynamic variable references.  For example, $(atem:short_1)'
 		}
 	]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "panasonic-ptz",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"ptz",


### PR DESCRIPTION
In addition to `tally on` and `tally off` actions with corresponding presets, this also adds a config option to watch a dynamic variable for determining when the camera tally should be on.  For example, when a switcher module changes the video source for its program output and updates a dynamic variable indicating the input being displayed, all the cameras can react to this change and update their tally lights accordingly.

<img width="581" alt="Screen Shot 2019-12-03 at 9 59 57 PM" src="https://user-images.githubusercontent.com/13731537/70109620-72405180-161a-11ea-9445-04e928611abd.png">

An `Enable` checkbox was added to allow the feature to be turned off since it does not seem possible to de-select or clear out a dropdown after a selection has been set.

The  `Tally On Value` field can be filled in with a literal value but also allows the use of dynamic variable expressions.

This feature does not add any polling.  It works by registering an event listener for the system `variable_changed` event (only when enabled and a variable has been selected).