### PR TITLE
Add CX350/4000 series support

### DIFF
--- a/src/choices.js
+++ b/src/choices.js
@@ -221,6 +221,59 @@ export const c = {
 		{ id: '0C', label: 'S.GAIN2' },
 		{ id: '0E', label: 'S.GAIN3' },
 	],
+	CHOICES_GAIN_CX350: [
+		{ id: '80', label: 'Auto' },
+		{ id: '81', label: 'Manual' },
+		{ id: '02', label: '-6dB' },
+		{ id: '03', label: '-5dB' },
+		{ id: '04', label: '-4dB' },
+		{ id: '05', label: '-3dB' },
+		{ id: '06', label: '-2dB' },
+		{ id: '07', label: '-1dB' },
+		{ id: '08', label: '0dB' },
+		{ id: '09', label: '1dB' },
+		{ id: '0A', label: '2dB' },
+		{ id: '0B', label: '3db' },
+		{ id: '0C', label: '4dB' },
+		{ id: '0D', label: '5dB' },
+		{ id: '0E', label: '6dB' },
+		{ id: '0F', label: '7dB' },
+		{ id: '10', label: '8dB' },
+		{ id: '11', label: '9dB' },
+		{ id: '12', label: '10dB' },
+		{ id: '13', label: '11dB' },
+		{ id: '14', label: '12dB' },
+		{ id: '15', label: '13dB' },
+		{ id: '16', label: '14dB' },
+		{ id: '17', label: '15dB' },
+		{ id: '18', label: '16dB' },
+		{ id: '19', label: '17dB' },
+		{ id: '1A', label: '18dB' },
+		{ id: '1B', label: '19dB' },
+		{ id: '1C', label: '20dB' },
+		{ id: '1D', label: '21dB' },
+		{ id: '1E', label: '22dB' },
+		{ id: '1F', label: '23dB' },
+		{ id: '20', label: '24dB' },
+		{ id: '21', label: '25dB' },
+		{ id: '22', label: '26dB' },
+		{ id: '23', label: '27dB' },
+		{ id: '24', label: '28dB' },
+		{ id: '25', label: '29dB' },
+		{ id: '26', label: '30dB' },
+		{ id: '27', label: '31dB' },
+		{ id: '28', label: '32dB' },
+		{ id: '29', label: '33dB' },
+		{ id: '2A', label: '34dB' },
+		{ id: '2B', label: '35dB' },
+		{ id: '2C', label: '36dB' },
+		{ id: '2D', label: '37dB' },
+		{ id: '2E', label: '38dB' },
+		{ id: '2F', label: '39dB' },
+		{ id: '30', label: '40dB' },
+		{ id: '31', label: '41dB' },
+		{ id: '32', label: '42dB' },
+	],
 	CHOICES_GAIN_HE60: function () {
 		return this.CHOICES_GAIN_HE50
 	},
@@ -378,6 +431,14 @@ export const c = {
 		return p
 	},
 
+	CHOICES_PEDESTAL_CX350: function () {
+		const p = []
+		for (let i = 0; i <= 400; ++i) {
+			p.push({ id: ('0' + i.toString(16)).substr(-3, 3).toUpperCase(), label: 'Pedestal ' + (i - 200) })
+		}
+		return p
+	},
+
 	CHOICES_PEDESTAL_HE42: function () {
 		return this.CHOICES_PEDESTAL_HE40()
 	},
@@ -440,6 +501,9 @@ export const c = {
 	},
 	CHOICES_FILTER_HE42: function () {
 		return this.CHOICES_FILTER_UE70
+	},
+	CHOICES_FILTER_CX350: function () {
+		return this.CHOICES_FILTER_HE120
 	},
 	CHOICES_FILTER_OTHER: function () {
 		return this.CHOICES_FILTER_UE70

--- a/src/models.js
+++ b/src/models.js
@@ -34,6 +34,11 @@ export const MODELS = [
 	{ id: 'AW-HEF5', series: 'AW-HEF5', label: 'AW-HEF5' },
 	{ id: 'AW-SFU01', series: 'AW-SFU01', label: 'AW-SFU01' },
 	{ id: 'AK-UB300', series: 'AK-UB300', label: 'AK-UB300' },
+	{ id: 'AG-CX350', series: 'CX350', label: 'AG-CX350' },
+	{ id: 'AG-CX200', series: 'CX350', label: 'AG-CX200' },
+	{ id: 'AJ-UPX360', series: 'CX350', label: 'AJ-UPX360' },
+	{ id: 'AJ-CX4000', series: 'CX350', label: 'AJ-CX4000' },
+	{ id: 'AJ-UPX900', series: 'CX350', label: 'AJ-UPX900' },
 	{ id: 'Other', series: 'Other', label: 'Other Cameras' },
 ]
 
@@ -53,6 +58,7 @@ export const MODELS = [
 // AW-UE4
 // AW-SHU01
 // AK-UB300
+// CX350
 
 export const SERIES_SPECS = [
 	{
@@ -777,6 +783,59 @@ export const SERIES_SPECS = [
 			tally: true,
 			tally2: true,
 			sdCard: false,
+			colorTemperature: false,
+		},
+	},
+
+	{
+		// Specific for the AG-CX350/4000 Camera
+		id: 'CX350',
+		variables: {
+			// Camera firmware lacks event update notification support
+			version: false, // If a camera sends a package every minute with the firmware version (qSV3)
+			error: false, // Camera can return Error messages when actions fail (rER)
+			ins: false, // Install position (iNS0 or iNS1)
+			power: false, // Power State (p1 or p0)
+			tally: false, // Red Tally State (DA1/TLR:1 or DA0/TLR:0)
+			tally2: false, // Green Tally State (TLG:1 or TLG:0)
+			OAF: false, // Has Auto Focus (OAF:1 or OAF:0)
+			iris: false, // Has Auto Iris (d30 or d31)
+			gainValue: false,
+			preset: false,
+			colorTemperature: false,
+		},
+		feedbacks: {
+			// Camera firmware lacks event update notification support
+			powerState: false, // Power State (p1 or p0)
+			tallyState: false, // Red Tally State (dA1/TLR:1 or dA0/TLR:0)
+			tally2State: false, // Green Tally State (TLG:1 or TLG:0)
+			insState: false, // Install position (iNS0 or iNS1)
+			autoFocus: false, // Has Auto Focus (OAF:1 or OAF:0)
+			autoIris: false, // Has Auto Iris (d30 or d31)
+			preset: false,			
+		},
+		actions: {
+			panTilt: false, // Has Pan/Tilt Support (PTSxx)
+			ptSpeed: false, // Internal Speed Options
+			zoom: true, // Has Zoom Support (Zxx)
+			zSpeed: true, // Internal Speed Options
+			focus: true, // Has Focus Support (Fxx)
+			fSpeed: true, // Internal Speed Options
+			OAF: true, // Has Auto Focus Support (D10 or D11)
+			OTAF: true, // Has One Touch Auto Focus Support (OSE:69:1)
+			iris: true, // Has Iris Support (manual and auto) (Ixx)
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_CX350() },
+			shut: false,
+			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_CX350() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_CX350() },
+			preset: false,
+			speedPset: false,
+			timePset: false,
+			power: true,
+			tally: true,
+			tally2: true,
+			ins: false,
+			sdCard: true,
 			colorTemperature: false,
 		},
 	},


### PR DESCRIPTION
Add basic support for

- AG-CX350
- AG-CX200
- AJ-UPX360
- AJ-CX4000
- AJ-UPX900

According to https://eww.pass.panasonic.co.jp/pro-av/support/content/guide/DEF/CX350_CX4000_Command_for_PTZ_Control_Protocol.pdf

Please note that the firmware of these camera models does not (yet?) support event update notification.
Therefore, there are no variables or feedback for these models as no status updates are transmitted from the camera back to companion.

Fixes #24