### PR TITLE
Support for non-TCP cameras, some bugfixes and other improvements

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,19 +3,6 @@ import { c } from './choices.js'
 import { getAndUpdateSeries } from './common.js'
 import got from 'got'
 
-// ########################
-// #### Value Look Ups ####
-// ########################
-const CHOICES_IRIS = []
-for (let i = 0; i < 100; ++i) {
-	CHOICES_IRIS.push({ id: ('0' + i.toString(10)).substr(-2, 2), label: 'Iris ' + i })
-}
-
-const CHOICES_PRESET = []
-for (let i = 0; i < 100; ++i) {
-	CHOICES_PRESET.push({ id: ('0' + i.toString(10)).substr(-2, 2), label: 'Preset ' + (i + 1) })
-}
-
 // ######################
 // #### Send Actions ####
 // ######################
@@ -828,12 +815,12 @@ export function getActionDefinitions(self) {
 			name: 'Exposure - Iris Up',
 			options: [],
 			callback: async (action) => {
-				if (self.irisIndex == CHOICES_IRIS.length) {
-					self.irisIndex = CHOICES_IRIS.length
-				} else if (self.irisIndex < CHOICES_IRIS.length) {
+				if (self.irisIndex == c.CHOICES_IRIS().length) {
+					self.irisIndex = c.CHOICES_IRIS().length
+				} else if (self.irisIndex < c.CHOICES_IRIS().length) {
 					self.irisIndex++
 				}
-				self.irisVal = CHOICES_IRIS[self.irisIndex].id
+				self.irisVal = c.CHOICES_IRIS()[self.irisIndex].id
 				await sendPTZ(self, 'I' + self.irisVal.toUpperCase())
 			},
 		}
@@ -849,7 +836,7 @@ export function getActionDefinitions(self) {
 				} else if (self.irisIndex > 0) {
 					self.irisIndex--
 				}
-				self.irisVal = CHOICES_IRIS[self.irisIndex].id
+				self.irisVal = c.CHOICES_IRIS()[self.irisIndex].id
 				await sendPTZ(self, 'I' + self.irisVal.toUpperCase())
 			},
 		}
@@ -863,8 +850,8 @@ export function getActionDefinitions(self) {
 					type: 'dropdown',
 					label: 'Iris setting',
 					id: 'val',
-					default: CHOICES_IRIS[0].id,
-					choices: CHOICES_IRIS,
+					default: c.CHOICES_IRIS()[0].id,
+					choices: c.CHOICES_IRIS(),
 				},
 			],
 			callback: async (action) => {
@@ -1217,16 +1204,14 @@ export function getActionDefinitions(self) {
 					type: 'dropdown',
 					label: 'Preset Nr.',
 					id: 'val',
-					default: CHOICES_PRESET[0].id,
-					choices: CHOICES_PRESET,
+					default: c.CHOICES_PRESET()[0].id,
+					choices: c.CHOICES_PRESET(),
 				},
 			],
 			callback: async (action) => {
 				await sendPTZ(self, 'M' + action.options.val)
 			},
 		}
-	}
-	if (seriesActions.preset) {
 		actions.recallPset = {
 			name: 'Preset - Recall',
 			options: [
@@ -1234,16 +1219,14 @@ export function getActionDefinitions(self) {
 					type: 'dropdown',
 					label: 'Preset Nr.',
 					id: 'val',
-					default: CHOICES_PRESET[0].id,
-					choices: CHOICES_PRESET,
+					default: c.CHOICES_PRESET()[0].id,
+					choices: c.CHOICES_PRESET(),
 				},
 			],
 			callback: async (action) => {
 				await sendPTZ(self, 'R' + action.options.val)
 			},
 		}
-	}
-	if (seriesActions.preset) {
 		actions.recallModePset = {
 			name: 'Preset - Mode A, B, C',
 			options: [
@@ -1375,6 +1358,22 @@ export function getActionDefinitions(self) {
 				callback: async (action) => {
 					await sendCam(self, 'TLG:1')
 				},
+			}
+			if (seriesActions.tally3)  {
+				actions.tally3Off = {
+					name: 'System - Yellow Tally Off',
+					options: [],
+					callback: async (action) => {
+						await sendCam(self, 'TLY:0')
+					},
+				}
+				actions.tally3On = {
+					name: 'System - Yellow Tally On',
+					options: [],
+					callback: async (action) => {
+						await sendCam(self, 'TLY:1')
+					},
+				}
 			}
 		} else { // Use legacy PTZ Tally
 			actions.tallyOff = {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1362,6 +1362,23 @@ export function getActionDefinitions(self) {
 		}
 	}
 
+	if (seriesActions.colorbar) {
+		actions.colorbarOff = {
+			name: 'System - Color Bar Off',
+			options: [],
+			callback: async (action) => {
+				await sendCam(self, 'DCB:0')
+			},
+		}
+		actions.colorbarOn = {
+			name: 'System - Color Bar On',
+			options: [],
+			callback: async (action) => {
+				await sendCam(self, 'DCB:1')
+			},
+		}
+	}
+
 	if (seriesActions.ins) {
 		actions.insPosition = {
 			name: 'System - Installation position',

--- a/src/actions.js
+++ b/src/actions.js
@@ -1062,6 +1062,38 @@ export function getActionDefinitions(self) {
 		}
 	}
 
+	if (seriesActions.whiteBalance) {
+		actions.whiteBalanceMode = {
+			name: 'White Balance - Mode',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Select Mode',
+					id: 'val',
+					default: '0',
+					choices: c.CHOICES_WB_SET,
+				},
+			],
+			callback: async (action) => {
+				await sendCam(self, 'OAW:' + action.options.val)
+			},
+		}
+		actions.whiteBalanceExecAWB = {
+			name: 'White Balance - Execute AWC/AWB',
+			options: [],
+			callback: async (action) => {
+				await sendCam(self, 'OWS')
+			},
+		}
+		actions.whiteBalanceExecABB = {
+			name: 'White Balance - Execute ABC/ABB',
+			options: [],
+			callback: async (action) => {
+				await sendCam(self, 'OAS')
+			},
+		}
+	}
+
 	if (seriesActions.colorTemperature) { 
 		actions.colorTemperatureUp = {
 			name: 'Color Temperature Up',
@@ -1256,7 +1288,7 @@ export function getActionDefinitions(self) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Time Secconds',
+					label: 'Time Seconds',
 					id: 'speed',
 					default: '001',
 					choices: c.CHOICES_PSTIME(),

--- a/src/actions.js
+++ b/src/actions.js
@@ -885,8 +885,8 @@ export function getActionDefinitions(self) {
 					id: 'bol',
 					default: 0,
 					choices: [
-						{ id: 0, label: 'Auto Iris' },
-						{ id: 1, label: 'Manual Iris' },
+						{ id: 0, label: 'Manual Iris' },
+						{ id: 1, label: 'Auto Iris' },
 					],
 				},
 			],

--- a/src/actions.js
+++ b/src/actions.js
@@ -1452,5 +1452,33 @@ export function getActionDefinitions(self) {
 		}
 	}
 
+	actions.sendCustom = {
+		name: 'Custom - Send Command',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Custom command destination',
+				id: 'dest',
+				default: '0',
+				choices: [
+					{ id: '0', label: 'Cam' },
+					{ id: '1', label: 'PTZ' },
+				],
+			},
+			{
+				id: 'cmd',
+				type: 'textinput',
+				label: 'Custom Command (without leading #)',
+				default: ''
+			}
+		],
+		callback: async (action) => {
+			switch (action.options.dest) {
+				case '0': await sendCam(self, action.options.cmd); break
+				case '1': await sendPTZ(self, action.options.cmd); break
+			}
+		},
+	}
+
 	return actions
 }

--- a/src/choices.js
+++ b/src/choices.js
@@ -286,9 +286,6 @@ export const c = {
 	CHOICES_GAIN_HE42: function () {
 		return this.CHOICES_GAIN_HE40
 	},
-	CHOICES_GAIN_CX350: function () {
-		return this.CHOICES_GAIN_CX350
-	},
 	CHOICES_GAIN_OTHER: function () {
 		return this.CHOICES_GAIN_HR140
 	},

--- a/src/choices.js
+++ b/src/choices.js
@@ -274,20 +274,77 @@ export const c = {
 		{ id: '31', label: '41dB' },
 		{ id: '32', label: '42dB' },
 	],
-	CHOICES_GAIN_HE60: function () {
-		return this.CHOICES_GAIN_HE50
-	},
-	CHOICES_GAIN_UE150: function () {
-		return this.CHOICES_GAIN_HR140
-	},
-	CHOICES_GAIN_UE70: function () {
-		return this.CHOICES_GAIN_HE40
-	},
-	CHOICES_GAIN_HE42: function () {
-		return this.CHOICES_GAIN_HE40
-	},
+	CHOICES_GAIN_UE150: [
+		{ id: '80', label: 'Auto' },
+		{ id: '05', label: '-3dB' },
+		{ id: '06', label: '-2dB' },
+		{ id: '07', label: '-1dB' },
+		{ id: '08', label: '0dB' },
+		{ id: '09', label: '1dB' },
+		{ id: '0A', label: '2dB' },
+		{ id: '0B', label: '3db' },
+		{ id: '0C', label: '4dB' },
+		{ id: '0D', label: '5dB' },
+		{ id: '0E', label: '6dB' },
+		{ id: '0F', label: '7dB' },
+		{ id: '10', label: '8dB' },
+		{ id: '11', label: '9dB' },
+		{ id: '12', label: '10dB' },
+		{ id: '13', label: '11dB' },
+		{ id: '14', label: '12dB' },
+		{ id: '15', label: '13dB' },
+		{ id: '16', label: '14dB' },
+		{ id: '17', label: '15dB' },
+		{ id: '18', label: '16dB' },
+		{ id: '19', label: '17dB' },
+		{ id: '1A', label: '18dB' },
+		{ id: '1B', label: '19dB' },
+		{ id: '1C', label: '20dB' },
+		{ id: '1D', label: '21dB' },
+		{ id: '1E', label: '22dB' },
+		{ id: '1F', label: '23dB' },
+		{ id: '20', label: '24dB' },
+		{ id: '21', label: '25dB' },
+		{ id: '22', label: '26dB' },
+		{ id: '23', label: '27dB' },
+		{ id: '24', label: '28dB' },
+		{ id: '25', label: '29dB' },
+		{ id: '26', label: '30dB' },
+		{ id: '27', label: '31dB' },
+		{ id: '28', label: '32dB' },
+		{ id: '29', label: '33dB' },
+		{ id: '2A', label: '34dB' },
+		{ id: '2B', label: '35dB' },
+		{ id: '2C', label: '36dB' },
+		{ id: '2D', label: '37dB' },
+		{ id: '2E', label: '38dB' },
+		{ id: '2F', label: '39dB' },
+		{ id: '30', label: '40dB' },
+		{ id: '31', label: '41dB' },
+		{ id: '32', label: '42dB' },
+	],
+	CHOICES_GAIN_UE160: [
+		{ id: '80', label: 'Auto' },
+		{ id: '04', label: '-4dB' },
+		{ id: '05', label: '-3dB' },
+		{ id: '06', label: '-2dB' },
+		{ id: '07', label: '-1dB' },
+		{ id: '08', label: '0dB' },
+		{ id: '09', label: '1dB' },
+		{ id: '0A', label: '2dB' },
+		{ id: '0B', label: '3db' },
+		{ id: '0C', label: '4dB' },
+		{ id: '0D', label: '5dB' },
+		{ id: '0E', label: '6dB' },
+		{ id: '0F', label: '7dB' },
+		{ id: '10', label: '8dB' },
+		{ id: '11', label: '9dB' },
+		{ id: '12', label: '10dB' },
+		{ id: '13', label: '11dB' },
+		{ id: '14', label: '12dB' },
+	],
 	CHOICES_GAIN_OTHER: function () {
-		return this.CHOICES_GAIN_HR140
+		return this.CHOICES_GAIN_CX350
 	},
 
 	// ##########################
@@ -414,49 +471,44 @@ export const c = {
 	// ###########################
 	CHOICES_PEDESTAL_HE40: function () {
 		const p = []
-		for (let i = 0; i <= 300; ++i) {
-			p.push({
-				id: ('00' + i.toString(16)).substr(-3, 3).toUpperCase(),
-				label: 'Pedestal ' + ((i - 150) / 15).toPrecision(3),
-			})
+		for (let i = -10; i <= 10; ++i) {
+			p.push({id: ((0x96 + (i * 15)).toString(16)).toUpperCase().padStart(3, '0'), label: 'Pedestal ' + i.toString() })
 		}
 		return p
 	},
 
 	CHOICES_PEDESTAL_HE120: function () {
 		const p = []
-		for (let i = 0; i <= 300; ++i) {
-			p.push({ id: ('00' + i.toString(16)).substr(-3, 3).toUpperCase(), label: 'Pedestal ' + (i - 150) })
+		for (let i = -150; i <= 150; ++i) {
+			p.push({ id: ((0x96 + i).toString(16)).toUpperCase().padStart(3, '0'), label: 'Pedestal ' + i.toString() })
 		}
 		return p
 	},
 
-	CHOICES_PEDESTAL_CX350: function () {
+	CHOICES_PEDESTAL_UE150: function () {
 		const p = []
-		for (let i = 0; i <= 400; ++i) {
-			p.push({ id: ('0' + i.toString(16)).substr(-3, 3).toUpperCase(), label: 'Pedestal ' + (i - 200) })
+		for (let i = -200; i <= 200; ++i) {
+			p.push({ id: ((0x800 + i).toString(16)).toUpperCase().padStart(3, '0'), label: 'Pedestal ' + i.toString() })
 		}
 		return p
 	},
 
-	CHOICES_PEDESTAL_HE42: function () {
-		return this.CHOICES_PEDESTAL_HE40()
+	CHOICES_PEDESTAL_UE20: function () {
+		const p = []
+		for (let i = -10; i <= 10; ++i) {
+			p.push({ id: ((0x800 + i).toString(16)).toUpperCase().padStart(3, '0'), label: 'Pedestal ' + i.toString() })
+		}
+		return p
 	},
-	CHOICES_PEDESTAL_HE50: function () {
-		return this.CHOICES_PEDESTAL_HE40()
+
+	CHOICES_PEDESTAL_UB300: function () {
+		const p = []
+		for (let i = -99; i <= 99; ++i) {
+			p.push({ id: ((0x80 + i).toString(16)).toUpperCase().padStart(2, '0'), label: 'Pedestal ' + i.toString() })
+		}
+		return p
 	},
-	CHOICES_PEDESTAL_HE60: function () {
-		return this.CHOICES_PEDESTAL_HE40()
-	},
-	CHOICES_PEDESTAL_UE70: function () {
-		return this.CHOICES_PEDESTAL_HE40()
-	},
-	CHOICES_PEDESTAL_HE130: function () {
-		return this.CHOICES_PEDESTAL_HE120()
-	},
-	CHOICES_PEDESTAL_HR140: function () {
-		return this.CHOICES_PEDESTAL_HE120()
-	},
+
 	CHOICES_PEDESTAL_OTHER: function () {
 		return this.CHOICES_PEDESTAL_HE120()
 	},
@@ -464,50 +516,35 @@ export const c = {
 	// ###########################
 	// #### ND Filter Look Ups ####
 	// ###########################
-	CHOICES_FILTER_UE70: [
-		{ id: '0', label: 'Through' },
-		{ id: '1', label: '1/4' },
-		{ id: '2', label: '1/16' },
-		{ id: '3', label: '1/64' },
-		{ id: '4', label: '1/8' },
-		{ id: '8', label: 'AUTO' },
+	CHOICES_FILTER_OTHER: [
+		{ id: '0', label: 'Clear (Through)' },
+		{ id: '1', label: '1/4 ND' },
+		{ id: '2', label: '1/16 ND' },
+		{ id: '3', label: '1/64 ND' },
+		{ id: '4', label: '1/8 ND' },
+		{ id: '8', label: 'AUTO ND' },
 	],
 
-	CHOICES_FILTER_HE120: [
-		{ id: '0', label: 'Through' },
-		{ id: '1', label: '1/4' },
-		{ id: '2', label: '1/16' },
-		{ id: '3', label: '1/64' },
+	CHOICES_FILTER_3A: [
+		{ id: '0', label: 'Clear (Through)' },
+		{ id: '1', label: '1/4 ND' },
+		{ id: '2', label: '1/16 ND' },
+		{ id: '3', label: '1/64 ND' },
+		{ id: '8', label: 'AUTO ND' },
 	],
 
-	CHOICES_FILTER_HE130: [
-		{ id: '0', label: 'Through' },
-		{ id: '3', label: '1/64' },
-		{ id: '4', label: '1/8' },
+	CHOICES_FILTER_3: [
+		{ id: '0', label: 'Clear (Through)' },
+		{ id: '1', label: '1/4 ND' },
+		{ id: '2', label: '1/16 ND' },
+		{ id: '3', label: '1/64 ND' },
 	],
 
-	CHOICES_FILTER_UB300: [
-		{ id: '0', label: 'Clear' },
-		{ id: '1', label: '1/4' },
-		{ id: '2', label: '1/16' },
-		{ id: '3', label: '1/64' },
+	CHOICES_FILTER_2: [
+		{ id: '0', label: 'Clear (Through)' },
+		{ id: '3', label: '1/64 ND' },
+		{ id: '4', label: '1/8 ND' },
 	],
-
-	CHOICES_FILTER_UE150: function () {
-		return this.CHOICES_FILTER_HE120
-	},
-	CHOICES_FILTER_HR140: function () {
-		return this.CHOICES_FILTER_HE130
-	},
-	CHOICES_FILTER_HE42: function () {
-		return this.CHOICES_FILTER_UE70
-	},
-	CHOICES_FILTER_CX350: function () {
-		return this.CHOICES_FILTER_HE120
-	},
-	CHOICES_FILTER_OTHER: function () {
-		return this.CHOICES_FILTER_UE70
-	},
 
 	// ###############################
 	// #### Preset Speed Look Ups ####

--- a/src/choices.js
+++ b/src/choices.js
@@ -352,6 +352,7 @@ export const c = {
 	// ##########################
 	CHOICES_SHUTTER_OTHER: [
 		{ id: '0', label: 'OFF' },
+		{ id: '1', label: '1/50' },
 		{ id: '2', label: '1/60' },
 		{ id: '3', label: '1/100' },
 		{ id: '4', label: '1/120' },
@@ -367,7 +368,7 @@ export const c = {
 		{ id: 'E', label: '1/25' },
 		{ id: 'F', label: '1/30' },
 	],
-	CHOICES_SHUTTER_HE50: [
+	CHOICES_SHUTTER_HE40: [
 		{ id: '0', label: 'OFF' },
 		{ id: '3', label: '1/100 (59.94Hz) or 1/120 (50Hz)' },
 		{ id: '5', label: '1/250' },
@@ -450,20 +451,12 @@ export const c = {
 		{ id: '11', label: '45.0 deg' },
 	],
 
-	CHOICES_SHUTTER_HE60: function () {
-		return this.CHOICES_SHUTTER_HE50
-	},
-	CHOICES_SHUTTER_HE40: function () {
-		return this.CHOICES_SHUTTER_HE50
-	},
-	CHOICES_SHUTTER_UE70: function () {
-		return this.CHOICES_SHUTTER_HE50
-	},
-	CHOICES_SHUTTER_HE42: function () {
-		return this.CHOICES_SHUTTER_HE50
-	},
-	CHOICES_SHUTTER_HR140: function () {
-		return this.CHOICES_SHUTTER_HE130
+	CHOICES_SHUTTER_UE150: function () {
+		const p = []
+		for (let i = 0x18; i <= 0x2710; ++i) {
+			p.push({ id: (i.toString(16)).toUpperCase().padStart(3, '0'), label: '/' + i.toString() })
+		}
+		return p
 	},
 
 	// ###########################
@@ -737,4 +730,28 @@ export const c = {
 		{ id: '8', label: 'Preset 2800K' },
 		{ id: '9', label: 'Var' },
 	],
+
+	// #########################
+	// #### Preset Look Ups ####
+	// #########################
+	CHOICES_PRESET: function () {
+		const p = []
+		for (let i = 0; i < 100; ++i) {
+			p.push({ id: i.toString(10).padStart(2, '0'), label: 'Preset ' + (i+1).toString() })
+		}
+		return p
+	},
+
+	// #######################
+	// #### Iris Look Ups ####
+	// #######################
+	CHOICES_IRIS: function () {
+		const p = []
+		p.push({ id: '01', label: 'Iris 1 (Close)' })
+		for (let i = 2; i < 99; ++i) {
+			p.push({ id: i.toString(10).padStart(2, '0'), label: 'Iris ' + i.toString() })
+		}
+		p.push({ id: '99', label: 'Iris 99 (Open)' })
+		return p
+	}
 }

--- a/src/choices.js
+++ b/src/choices.js
@@ -676,4 +676,28 @@ export const c = {
 		{ "id": "077", "label": "14000K" },
 		{ "id": "078", "label": "15000K" },
 	],
+
+	// ################################
+	// #### White Balance Look Ups ####
+	// ################################
+	CHOICES_WB_SET: [
+		{ id: '0', label: 'ATW' },
+		{ id: '1', label: 'AWC A' },
+		{ id: '2', label: 'AWC B' },
+		{ id: '4', label: 'Preset 3200K' },
+		{ id: '5', label: 'Preset 5600K' },
+		{ id: '9', label: 'Var' },
+	],
+	CHOICES_WB_GET: [
+		{ id: '0', label: 'ATW' },
+		{ id: '1', label: 'AWC A' },
+		{ id: '2', label: 'AWC B' },
+		{ id: '3', label: 'ATW' },
+		{ id: '4', label: 'Preset 3200K' },
+		{ id: '5', label: 'Preset 5600K' },
+		{ id: '6', label: 'Preset 4500K' },
+		{ id: '7', label: 'Preset 6000K' },	
+		{ id: '8', label: 'Preset 2800K' },
+		{ id: '9', label: 'Var' },
+	],
 }

--- a/src/common.js
+++ b/src/common.js
@@ -3,7 +3,7 @@ import { MODELS, SERIES_SPECS } from './models.js'
 export function getAndUpdateSeries(self) {
 	// Set the model and series selected, if in auto, dettect what model is connected via TCP
 	if (self.config.model === 'Auto') {
-		self.data.model = self.data.modelTCP
+		self.data.model = self.data.modelINFO
 	} else {
 		self.data.model = self.config.model
 	}

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ export const ConfigFields = [
 		width: 12,
 		label: 'Information',
 		value:
-			"This module controls Panasonic PTZ cameras, you can find supported models in the dropdown below.<br/>If your camera isn't in the list below, feel free to try it anyway the option 'Other Cameras'.",
+			"This module controls Panasonic PTZ cameras, you can find supported models in the dropdown below.<br/>If your camera isn't in the list below, feel free to try it anyway by option 'Other Cameras'.",
 	},
 	{
 		type: 'textinput',
@@ -37,7 +37,7 @@ export const ConfigFields = [
 		id: 'modelInfo',
 		width: 12,
 		label: 'Camera Model',
-		value: 'Please Select the camera model or feel free to leave it on auto.',
+		value: "Please select the camera model or feel free to leave it on 'Auto Detect'.",
 	},
 	{
 		type: 'dropdown',
@@ -57,28 +57,12 @@ export const ConfigFields = [
 	},
 	{
 		type: 'static-text',
-		id: 'info',
-		width: 12,
-		label: 'Tally On (Basic)',
-		value:
-			'Support for Tally On is no longer possible. Instead you can set this up as a trigger, and get additional control',
-	},
-	{
-		type: 'static-text',
-		id: 'dummy3',
-		width: 12,
-		label: ' ',
-		value: ' ',
-	},
-	{
-		type: 'static-text',
 		id: 'Info',
 		width: 12,
 		label: 'Other Settings',
 		value:
 			'These setting can be left on the default values and should give you a consistent setup, but they are there for you to use if need be.',
 	},
-
 	{
 		type: 'checkbox',
 		id: 'autoTCP',
@@ -90,8 +74,8 @@ export const ConfigFields = [
 		type: 'static-text',
 		id: 'autoTCPInfo',
 		width: 4,
-		label: 'Auto TCP',
-		value: 'This will ignore the port selected and find a port Automaticly',
+		label: 'Automatic local TCP port assignment',
+		value: 'This will ignore the manual port selection and find a free port automatically',
 	},
 	{
 		type: 'number',
@@ -106,8 +90,8 @@ export const ConfigFields = [
 		type: 'static-text',
 		id: 'manualTCPInfo',
 		width: 4,
-		label: 'Manual TCP Port',
-		value: 'TCP Port (Default: 31004) only used when "Auto TCP" is OFF/Disabled',
+		label: 'Manual local TCP port assignment',
+		value: 'TCP Port (Default: 31004) only used when "Automatic TCP port assignment" is disabled',
 	},
 	{
 		type: 'checkbox',

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,14 +1,6 @@
 import { combineRgb } from '@companion-module/base'
 import { getAndUpdateSeries } from './common.js'
-import { CHOICES_WB_GET } from "./choices.js"
-
-// ########################
-// #### Value Look Ups ####
-// ########################
-const CHOICES_PRESET = []
-for (let i = 0; i < 100; ++i) {
-	CHOICES_PRESET.push({ id: ('0' + (i+1).toString(10)).substr(-2, 2), label: 'Preset ' + (i + 1) })
-}
+import { c } from './choices.js'
 
 // ##########################
 // #### Define Feedbacks ####
@@ -28,41 +20,15 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.powerState = {
 			type: 'boolean',
 			name: 'System - Power State',
-			description: 'Indicate if Camera is ON or OFF',
+			description: 'Indicates if the camera is currently powered on',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Indicate Power State',
-					id: 'option',
-					default: '1',
-					choices: [
-						{ id: '0', label: 'OFF' },
-						{ id: '1', label: 'ON' },
-					],
-				},
-			],
+			options: [],
 			callback: function (feedback) {
-				const opt = feedback.options
-				switch (opt.option) {
-					case '0':
-						if (self.data.power === 'OFF') {
-							return true
-						}
-						break
-					case '1':
-						if (self.data.power === 'ON') {
-							return true
-						}
-						break
-					default:
-						break
-				}
-				return false
-			},
+				return self.data.power === 'ON'
+			}
 		}
 	}
 
@@ -70,7 +36,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.colorbarState = {
 			type: 'boolean',
 			name: 'System - Color Bar State',
-			description: 'Indicates whether the color bar is currently ENABLED on this camera',
+			description: 'Indicates if the color bar is currently enabled on this camera',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
@@ -86,40 +52,14 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.tallyState = {
 			type: 'boolean',
 			name: 'System - Red Tally State',
-			description: 'Indicate if red Tally is ON or OFF',
+			description: 'Indicates if the red Tally is currently active',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Indicate in X State',
-					id: 'option',
-					default: '1',
-					choices: [
-						{ id: '0', label: 'OFF' },
-						{ id: '1', label: 'ON' },
-					],
-				},
-			],
+			options: [],
 			callback: function (feedback) {
-				const opt = feedback.options
-				switch (opt.option) {
-					case '0':
-						if (self.data.tally === 'OFF') {
-							return true
-						}
-						break
-					case '1':
-						if (self.data.tally === 'ON') {
-							return true
-						}
-						break
-					default:
-						break
-				}
-				return false
+				return self.data.tally === 'ON'
 			},
 		}
 	}
@@ -128,40 +68,30 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.tally2State = {
 			type: 'boolean',
 			name: 'System - Green Tally State',
-			description: 'Indicate if green Tally is ON or OFF',
+			description: 'Indicates if the green Tally is currently active',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorGreen,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Indicate in X State',
-					id: 'option',
-					default: '1',
-					choices: [
-						{ id: '0', label: 'OFF' },
-						{ id: '1', label: 'ON' },
-					],
-				},
-			],
+			options: [],
 			callback: function (feedback) {
-				const opt = feedback.options
-				switch (opt.option) {
-					case '0':
-						if (self.data.tally2 === 'OFF') {
-							return true
-						}
-						break
-					case '1':
-						if (self.data.tally2 === 'ON') {
-							return true
-						}
-						break
-					default:
-						break
-				}
-				return false
+				return self.data.tally2 === 'ON'
+			},
+		}
+	}
+
+	if (SERIES.feedbacks.tally3State) {
+		feedbacks.tally3State = {
+			type: 'boolean',
+			name: 'System - Yellow Tally State',
+			description: 'Indicates if the yellow Tally is currently active',
+			defaultStyle: {
+				color: foregroundColor,
+				bgcolor: backgroundColorOrange,
+			},
+			options: [],
+			callback: function (feedback) {
+				return self.data.tally3 === 'ON'
 			},
 		}
 	}
@@ -170,7 +100,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.insState = {
 			type: 'boolean',
 			name: 'System - Install Position',
-			description: 'Indicate if PTZ is on Desktop or Hanging',
+			description: 'Indicates the currently selected mounting position',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
@@ -178,9 +108,9 @@ export function getFeedbackDefinitions(self) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Indicate in X position',
+					label: 'Position',
 					id: 'option',
-					default: '1',
+					default: '0',
 					choices: [
 						{ id: '0', label: 'Desktop' },
 						{ id: '1', label: 'Hanging' },
@@ -200,8 +130,6 @@ export function getFeedbackDefinitions(self) {
 							return true
 						}
 						break
-					default:
-						break
 				}
 				return false
 			},
@@ -212,40 +140,14 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.autoFocus = {
 			type: 'boolean',
 			name: 'Lens - Auto Focus State',
-			description: 'Indicate if Auto focus is ON or OFF',
+			description: 'Indicates if Auto Focus is currently enabled',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Indicate in X State',
-					id: 'option',
-					default: '1',
-					choices: [
-						{ id: '0', label: 'Manual' },
-						{ id: '1', label: 'Auto' },
-					],
-				},
-			],
+			options: [],
 			callback: function (feedback) {
-				const opt = feedback.options
-				switch (opt.option) {
-					case '0':
-						if (self.data.oaf === 'Manual') {
-							return true
-						}
-						break
-					case '1':
-						if (self.data.oaf === 'Auto') {
-							return true
-						}
-						break
-					default:
-						break
-				}
-				return false
+				return self.data.oaf === 'Auto'
 			},
 		}
 	}
@@ -254,40 +156,14 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.autoIris = {
 			type: 'boolean',
 			name: 'Lens - Auto Iris State',
-			description: 'Indicate if Auto iris is ON or OFF',
+			description: 'Indicates if Auto Iris is currently enabled',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
 			},
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Indicate in X State',
-					id: 'option',
-					default: '1',
-					choices: [
-						{ id: '0', label: 'Manual' },
-						{ id: '1', label: 'Auto' },
-					],
-				},
-			],
+			options: [],
 			callback: function (feedback) {
-				const opt = feedback.options
-				switch (opt.option) {
-					case '0':
-						if (self.data.irisMode === 'Manual') {
-							return true
-						}
-						break
-					case '1':
-						if (self.data.irisMode === 'Auto') {
-							return true
-						}
-						break
-					default:
-						break
-				}
-				return false
+				return self.data.irisMode === 'Auto'
 			},
 		}
 	}
@@ -296,7 +172,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.recallModePset = {
 			type: 'boolean',
 			name: 'Preset - Mode A, B, C',
-			description: 'Indicate what preset mode is currently selected on the camera',
+			description: 'Indicates which preset recall mode is currently selected',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
@@ -304,7 +180,7 @@ export function getFeedbackDefinitions(self) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Select Mode',
+					label: 'Mode',
 					id: 'option',
 					default: '0',
 					choices: [
@@ -338,10 +214,10 @@ export function getFeedbackDefinitions(self) {
 				return false
 			},
 		}
-		feedbacks.presetCompletion = {
+		feedbacks.presetComplete = {
 			type: 'boolean',
 			name: 'Preset - Recall Completion Notification',
-			description: 'Indicate if recalled preset is completed',
+			description: 'Indicates if the last preset recall is completed',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorOrange,
@@ -349,14 +225,14 @@ export function getFeedbackDefinitions(self) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Preset Nr.',
+					label: 'Preset',
 					id: 'option',
-					default: CHOICES_PRESET[0].id,
-					choices: CHOICES_PRESET,
+					default: c.CHOICES_PRESET()[0].id,
+					choices: c.CHOICES_PRESET(),
 				},
 			],
 			callback: function (feedback) {
-				return (self.data.lastPresetCompleted === feedback.options.option) ? true : false
+				return self.data.lastPresetCompleted === parseInt(feedback.options.option)
 			},
 		}
 	}
@@ -375,12 +251,12 @@ export function getFeedbackDefinitions(self) {
 					type: 'dropdown',
 					label: 'Mode',
 					id: 'option',
-					default: CHOICES_WB_GET[0].id,
-					choices: CHOICES_WB_GET,
+					default: c.CHOICES_WB_GET[0].id,
+					choices: c.CHOICES_WB_GET,
 				},
 			],
 			callback: function (feedback) {
-				return (self.data.whiteBalance === feedback.options.option) ? true : false
+				return self.data.whiteBalance === feedback.options.option
 			},
 		}
 	}

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -19,7 +19,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.powerState = {
 			type: 'boolean',
 			name: 'System - Power State',
-			description: 'Indicate if PTZ is ON or OFF',
+			description: 'Indicate if Camera is ON or OFF',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
@@ -27,7 +27,7 @@ export function getFeedbackDefinitions(self) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Indicate in X State',
+					label: 'Indicate Power State',
 					id: 'option',
 					default: '1',
 					choices: [
@@ -53,6 +53,22 @@ export function getFeedbackDefinitions(self) {
 						break
 				}
 				return false
+			},
+		}
+	}
+
+	if (SERIES.feedbacks.colorbarState) {
+		feedbacks.colorbarState = {
+			type: 'boolean',
+			name: 'System - Color Bar State',
+			description: 'Indicates whether the color bar is currently ENABLED on this camera',
+			defaultStyle: {
+				color: foregroundColor,
+				bgcolor: backgroundColorRed,
+			},
+			options: [],
+			callback: function (feedback) {
+				return self.data.colorbar
 			},
 		}
 	}

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -339,7 +339,7 @@ export function getFeedbackDefinitions(self) {
 		}
 		feedbacks.presetCompletion = {
 			type: 'boolean',
-			name: 'Preset Completion Notification',
+			name: 'Preset - Recall Completion Notification',
 			description: 'Indicate if recalled preset is completed',
 			defaultStyle: {
 				color: foregroundColor,

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,6 +1,14 @@
 import { combineRgb } from '@companion-module/base'
 import { getAndUpdateSeries } from './common.js'
 
+// ########################
+// #### Value Look Ups ####
+// ########################
+const CHOICES_PRESET = []
+for (let i = 0; i < 100; ++i) {
+	CHOICES_PRESET.push({ id: ('0' + (i+1).toString(10)).substr(-2, 2), label: 'Preset ' + (i + 1) })
+}
+
 // ##########################
 // #### Define Feedbacks ####
 // ##########################
@@ -287,7 +295,7 @@ export function getFeedbackDefinitions(self) {
 		feedbacks.recallModePset = {
 			type: 'boolean',
 			name: 'Preset - Mode A, B, C',
-			description: 'Indicate what preset mode is curently selected on the camera',
+			description: 'Indicate what preset mode is currently selected on the camera',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColorRed,
@@ -327,6 +335,27 @@ export function getFeedbackDefinitions(self) {
 						break
 				}
 				return false
+			},
+		}
+		feedbacks.presetCompletion = {
+			type: 'boolean',
+			name: 'Preset Completion Notification',
+			description: 'Indicate if recalled preset is completed',
+			defaultStyle: {
+				color: foregroundColor,
+				bgcolor: backgroundColorOrange,
+			},
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Preset Nr.',
+					id: 'val',
+					default: CHOICES_PRESET[0].id,
+					choices: CHOICES_PRESET,
+				},
+			],
+			callback: function (feedback) {
+				return (self.data.lastPresetCompleted == feedback.options.val) ? true : false
 			},
 		}
 	}

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,5 +1,6 @@
 import { combineRgb } from '@companion-module/base'
 import { getAndUpdateSeries } from './common.js'
+import { CHOICES_WB_GET } from "./choices.js"
 
 // ########################
 // #### Value Look Ups ####
@@ -349,13 +350,37 @@ export function getFeedbackDefinitions(self) {
 				{
 					type: 'dropdown',
 					label: 'Preset Nr.',
-					id: 'val',
+					id: 'option',
 					default: CHOICES_PRESET[0].id,
 					choices: CHOICES_PRESET,
 				},
 			],
 			callback: function (feedback) {
-				return (self.data.lastPresetCompleted == feedback.options.val) ? true : false
+				return (self.data.lastPresetCompleted === feedback.options.option) ? true : false
+			},
+		}
+	}
+
+	if (SERIES.feedbacks.whiteBalance) {
+		feedbacks.whiteBalanceMode = {
+			type: 'boolean',
+			name: 'White Balance - Mode',
+			description: 'Indicates whether the selected white balance mode is currently active',
+			defaultStyle: {
+				color: foregroundColor,
+				bgcolor: backgroundColorRed,
+			},
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Mode',
+					id: 'option',
+					default: CHOICES_WB_GET[0].id,
+					choices: CHOICES_WB_GET,
+				},
+			],
+			callback: function (feedback) {
+				return (self.data.whiteBalance === feedback.options.option) ? true : false
 			},
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -292,19 +292,22 @@ class PanasonicPTZInstance extends InstanceBase {
 			case 'OBR':
 				this.data.colorbar = (str[1] == '1') ? true : false
 				break
-			case 'dA0':
+			case 'dA0': // Legacy (red) Tally Off
 				this.data.tally = 'OFF'
 				break
-			case 'dA1':
+			case 'dA1': // Legacy (red) Tally On
 				this.data.tally = 'ON'
 				break
-			case 'TLR':
+			case 'TLR': // Tally Red
 				this.data.tally = (str[1] == '1') ? 'ON' : 'OFF'
 				break
-			case 'TLG':
+			case 'TLG': // Tally Green
 				this.data.tally2 = (str[1] == '1') ? 'ON' : 'OFF'
 				break
-			case 'iNS0':
+			case 'TLY': // Tally Yellow
+				this.data.tally3 = (str[1] == '1') ? 'ON' : 'OFF'
+				break
+				case 'iNS0':
 				this.data.ins = 'Desktop'
 				break
 			case 'iNS1':
@@ -373,6 +376,7 @@ class PanasonicPTZInstance extends InstanceBase {
 			ins: 'NaN',
 			tally: 'NaN',
 			tally2: 'NaN',
+			tally3: 'NaN',
 			oaf: 'NaN',
 			whiteBalance: null,
 			colorTemperature: 'Unknown',

--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ class PanasonicPTZInstance extends InstanceBase {
 		switch (str[0]) {
 			case 'OID':
 				this.data.modelTCP = str[1]
-				// if a new model is detected or seected, re-initialise all actions, variable and feedbacks
+				// if a new model is detected or selected, re-initialise all actions, variables and feedbacks
 				if (this.data.modelTCP !== this.data.model) {
 					this.init_actions() // export actions
 					this.init_presets()

--- a/src/index.js
+++ b/src/index.js
@@ -299,18 +299,10 @@ class PanasonicPTZInstance extends InstanceBase {
 				this.data.tally = 'ON'
 				break
 			case 'TLR':
-				if (str[1] == '0') {
-					this.data.tally = 'OFF'
-				} else if (str[1] == '1') {
-					this.data.tally = 'ON'
-				}
+				this.data.tally = (str[1] == '1') ? 'ON' : 'OFF'
 				break
 			case 'TLG':
-				if (str[1] == '0') {
-					this.data.tally2 = 'OFF'
-				} else if (str[1] == '1') {
-					this.data.tally2 = 'ON'
-				}
+				this.data.tally2 = (str[1] == '1') ? 'ON' : 'OFF'
 				break
 			case 'iNS0':
 				this.data.ins = 'Desktop'
@@ -319,11 +311,7 @@ class PanasonicPTZInstance extends InstanceBase {
 				this.data.ins = 'Hanging'
 				break
 			case 'OAF':
-				if (str[1] == '0') {
-					this.data.oaf = 'Manual'
-				} else if (str[1] == '1') {
-					this.data.oaf = 'Auto'
-				}
+				this.data.tally = (str[1] == '1') ? 'Auto' : 'Manual'
 				break
 			case 'OAW':
 				this.data.whiteBalance = str[1];
@@ -341,13 +329,10 @@ class PanasonicPTZInstance extends InstanceBase {
 				break
 			case 'OSE': // All OSE:xx Commands
 				if (str[1] == '71') {
-					// OSE:71:
-					if (str[2] == '0') {
-						this.data.recallModePset = 'Mode A'
-					} else if (str[2] == '1') {
-						this.data.recallModePset = 'Mode B'
-					} else if (str[2] == '2') {
-						this.data.recallModePset = 'Mode C'
+					switch (str[2]) {
+						case '0': this.data.recallModePset = 'Mode A'; break
+						case '1': this.data.recallModePset = 'Mode B'; break
+						case '2': this.data.recallModePset = 'Mode C'; break
 					}
 				}
 				break

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class PanasonicPTZInstance extends InstanceBase {
 					str_raw = str_raw.split('\r\n') // Split Data in order to remove data before and after command
 					let str = str_raw[1].trim() // remove new line, carage return and so on.
 					if (this.config.debug) {
-						this.log('info', 'Recived CMD: ' + String(str))
+						this.log('info', 'Received TCP:' + String(str))
 					}
 					str = str.split(':') // Split Commands and data
 
@@ -230,7 +230,7 @@ class PanasonicPTZInstance extends InstanceBase {
 							// remove new line, carage return and so on.
 							const str = line.trim().split(':') // Split Commands and data
 							if (this.config.debug) {
-								this.log('info', 'Recived CMD: ' + String(str))
+								this.log('info', 'Received Status: ' + String(str))
 							}
 							// Store Data
 							this.parseStatus(str)
@@ -325,12 +325,14 @@ class PanasonicPTZInstance extends InstanceBase {
 					this.data.oaf = 'Auto'
 				}
 				break
+			case 'OAW':
+				this.data.whiteBalance = str[1];
+				break;
 			case 'OSD':
-				if(str[1] == 'B1')
-				{
-					this.data.colorTemperature = str[2];
+				if (str[1] == 'B1') {
+					this.data.colorTemperature = str[2]
 				}
-			break;
+				break;
 			case 'd30':
 				this.data.irisMode = 'Manual'
 				break
@@ -387,6 +389,7 @@ class PanasonicPTZInstance extends InstanceBase {
 			tally: 'NaN',
 			tally2: 'NaN',
 			oaf: 'NaN',
+			whiteBalance: null,
 			colorTemperature: 'Unknown',
 			irisMode: 'NaN',
 			recallModePset: 'NaN',

--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,12 @@ class PanasonicPTZInstance extends InstanceBase {
 			}
 		}
 
+		// Store last Preset completed
+		const q = str[0].match(/q(\d\d)/)
+		if (q) {
+			this.data.lastPresetCompleted = parseInt(q[1])+1
+		}
+
 		// Store Firmware Version (not supported for the AK-UB300.)
 		if (str[0].substring(0, 4) === 'qSV3') {
 			this.data.version = str[0].substring(4)
@@ -384,6 +390,7 @@ class PanasonicPTZInstance extends InstanceBase {
 			colorTemperature: 'Unknown',
 			irisMode: 'NaN',
 			recallModePset: 'NaN',
+			lastPresetCompleted: null,
 		}
 
 		this.ptSpeed = 25

--- a/src/index.js
+++ b/src/index.js
@@ -282,6 +282,10 @@ class PanasonicPTZInstance extends InstanceBase {
 			case 'p0':
 				this.data.power = 'OFF'
 				break
+			case 'DCB':
+			case 'OBR':
+				this.data.colorbar = (str[1] == '1') ? true : false
+				break
 			case 'dA0':
 				this.data.tally = 'OFF'
 				break
@@ -372,6 +376,7 @@ class PanasonicPTZInstance extends InstanceBase {
 			version: 'NaN',
 			error: 'NaN',
 			power: 'NaN',
+			colorbar: null,
 			ins: 'NaN',
 			tally: 'NaN',
 			tally2: 'NaN',

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class PanasonicPTZInstance extends InstanceBase {
 					str_raw = str_raw.split('\r\n') // Split Data in order to remove data before and after command
 					let str = str_raw[1].trim() // remove new line, carage return and so on.
 					if (this.config.debug) {
-						this.log('info', 'Received TCP:' + String(str))
+						this.log('info', 'Received TCP: ' + String(str))
 					}
 					str = str.split(':') // Split Commands and data
 
@@ -340,12 +340,18 @@ class PanasonicPTZInstance extends InstanceBase {
 				break
 			case 'OAW':
 				this.data.whiteBalance = str[1];
-				break;
+				break
+			case 'OIF':
+				this.data.irisF = parseInt(str[1], 16);
+				break
+			case 'OIS':
+				this.data.ois = str[1];
+				break
 			case 'OSD':
 				if (str[1] == 'B1') {
 					this.data.colorTemperature = str[2]
 				}
-				break;
+				break
 			case 'd30':
 				this.data.irisMode = 'Manual'
 				break
@@ -408,6 +414,8 @@ class PanasonicPTZInstance extends InstanceBase {
 			zoomPosition: null,
 			focusPosition: null,
 			irisPosition: null,
+			irisF: null,
+			ois: null,
 		}
 
 		this.ptSpeed = 25

--- a/src/models.js
+++ b/src/models.js
@@ -831,7 +831,7 @@ export const SERIES_SPECS = [
 			preset: false,
 			speedPset: false,
 			timePset: false,
-			power: true,
+			power: false,
 			tally: true,
 			tally2: true,
 			ins: false,

--- a/src/models.js
+++ b/src/models.js
@@ -62,13 +62,14 @@ export const MODELS = [
 
 export const SERIES_SPECS = [
 	{
-		// Includes all Actions / Variabels / Feedbacks
+		// Includes all Actions / Variables / Feedbacks
 		id: 'Other',
 		variables: {
 			version: true, // If a camera sends a package every minute with the firmware version (qSV3)
 			error: true, // Camera can return Error messages when actions fail (rER)
 			ins: true, // Install position (iNS0 or iNS1)
 			power: true, // Power State (p1 or p0)
+			colorbar: true, // Color Bar State (OBR:1 or OBR:0)
 			tally: true, // Red Tally State (DA1/TLR:1 or DA0/TLR:0)
 			tally2: true, // Green Tally State (TLG:1 or TLG:0)
 			OAF: true, // Has Auto Focus (OAF:1 or OAF:0)
@@ -79,6 +80,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true, // Power State (p1 or p0)
+			colorbarState: true, // Color Bar State (OBR:1 or OBR:0)
 			tallyState: true, // Red Tally State (dA1/TLR:1 or dA0/TLR:0)
 			tally2State: true, // Green Tally State (TLG:1 or TLG:0)
 			insState: true, // Install position (iNS0 or iNS1)
@@ -104,6 +106,7 @@ export const SERIES_SPECS = [
 			speedPset: true, // Has Preset Recall Speed Control (UPVSxx)
 			timePset: true, // Has Preset Recall Time Control (UPVSxx or OSJ:29:xx)
 			power: true, // Has Power Control (O0 or O1)
+			colorbar: true, // Has Color Bar Control (DCB:1 or DCB:0)
 			tally: true, // Has Red Tally Light Control (DA1/TLR:1 or DA0/TLR:0)
 			tally2: true, // Has Green Tally Light Control (TLG:1 or TLG:0)
 			ins: true, // Has Install Position Control (INSx)
@@ -120,6 +123,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -129,6 +133,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -153,6 +158,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: true,
@@ -168,6 +174,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -177,6 +184,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -201,6 +209,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: true,
@@ -216,6 +225,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -225,6 +235,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -249,6 +260,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: true,
@@ -264,6 +276,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			tally2: true,
 			OAF: true,
@@ -274,6 +287,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			tally2State: true,
 			insState: true,
@@ -300,6 +314,7 @@ export const SERIES_SPECS = [
 			timePset: true,
 			power: true,
 			ins: true,
+			colorbar: true,
 			tally: true,
 			tally2: true,
 			sdCard: false,
@@ -315,6 +330,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: false,
 			iris: true,
@@ -324,6 +340,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: false,
 			autoFocus: false,
@@ -348,6 +365,7 @@ export const SERIES_SPECS = [
 			speedPset: false,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: false,
 			sdCard: false,
@@ -363,6 +381,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -372,6 +391,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -396,6 +416,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -411,6 +432,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -420,6 +442,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -444,6 +467,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -459,6 +483,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -468,6 +493,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -492,6 +518,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -507,6 +534,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -516,6 +544,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -540,6 +569,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -555,6 +585,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -564,6 +595,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -588,6 +620,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -603,6 +636,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -612,6 +646,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -636,6 +671,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -651,6 +687,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: false,
 			iris: true,
@@ -660,6 +697,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: false,
@@ -684,6 +722,7 @@ export const SERIES_SPECS = [
 			speedPset: false,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -699,6 +738,7 @@ export const SERIES_SPECS = [
 			error: true,
 			ins: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			OAF: true,
 			iris: true,
@@ -708,6 +748,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			tallyState: true,
 			insState: true,
 			autoFocus: true,
@@ -732,6 +773,7 @@ export const SERIES_SPECS = [
 			speedPset: true,
 			timePset: false,
 			power: true,
+			colorbar: true,
 			tally: true,
 			ins: true,
 			sdCard: false,
@@ -746,6 +788,7 @@ export const SERIES_SPECS = [
 			version: false,
 			error: true,
 			power: true,
+			colorbar: true,
 			tally: true,
 			tally2: true,
 			ins: false,
@@ -756,6 +799,7 @@ export const SERIES_SPECS = [
 		},
 		feedbacks: {
 			powerState: true,
+			colorbarState: true,
 			insState: false,
 			autoFocus: false,
 			autoIris: false,
@@ -780,6 +824,7 @@ export const SERIES_SPECS = [
 			timePset: false,
 			power: false,
 			ins: false,
+			colorbar: true,
 			tally: true,
 			tally2: true,
 			sdCard: false,
@@ -791,39 +836,41 @@ export const SERIES_SPECS = [
 		// Specific for the AG-CX350/4000 Camera
 		id: 'CX350',
 		variables: {
-			// Camera firmware lacks event update notification support
-			version: false, // If a camera sends a package every minute with the firmware version (qSV3)
-			error: false, // Camera can return Error messages when actions fail (rER)
-			ins: false, // Install position (iNS0 or iNS1)
-			power: false, // Power State (p1 or p0)
-			tally: false, // Red Tally State (DA1/TLR:1 or DA0/TLR:0)
-			tally2: false, // Green Tally State (TLG:1 or TLG:0)
-			OAF: false, // Has Auto Focus (OAF:1 or OAF:0)
-			iris: false, // Has Auto Iris (d30 or d31)
+			// Camera firmware lacks event update notification support!
+			version: false,
+			error: false,
+			ins: false,
+			power: false,
+			colorbar: false,
+			tally: false,
+			tally2: false,
+			OAF: false,
+			iris: false,
 			gainValue: false,
 			preset: false,
 			colorTemperature: false,
 		},
 		feedbacks: {
-			// Camera firmware lacks event update notification support
-			powerState: false, // Power State (p1 or p0)
-			tallyState: false, // Red Tally State (dA1/TLR:1 or dA0/TLR:0)
-			tally2State: false, // Green Tally State (TLG:1 or TLG:0)
-			insState: false, // Install position (iNS0 or iNS1)
-			autoFocus: false, // Has Auto Focus (OAF:1 or OAF:0)
-			autoIris: false, // Has Auto Iris (d30 or d31)
+			// Camera firmware lacks event update notification support!
+			powerState: false,
+			colorbarState: false,
+			tallyState: false,
+			tally2State: false,
+			insState: false,
+			autoFocus: false,
+			autoIris: false,
 			preset: false,			
 		},
 		actions: {
-			panTilt: false, // Has Pan/Tilt Support (PTSxx)
-			ptSpeed: false, // Internal Speed Options
-			zoom: true, // Has Zoom Support (Zxx)
-			zSpeed: true, // Internal Speed Options
-			focus: true, // Has Focus Support (Fxx)
-			fSpeed: true, // Internal Speed Options
-			OAF: true, // Has Auto Focus Support (D10 or D11)
-			OTAF: true, // Has One Touch Auto Focus Support (OSE:69:1)
-			iris: true, // Has Iris Support (manual and auto) (Ixx)
+			panTilt: false,
+			ptSpeed: false,
+			zoom: true,
+			zSpeed: true,
+			focus: true,
+			fSpeed: true,
+			OAF: true,
+			OTAF: true,
+			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_CX350 },
 			shut: false,
 			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_CX350() },
@@ -832,6 +879,7 @@ export const SERIES_SPECS = [
 			speedPset: false,
 			timePset: false,
 			power: false,
+			colorbar: true,
 			tally: true,
 			tally2: true,
 			ins: false,

--- a/src/models.js
+++ b/src/models.js
@@ -2,38 +2,44 @@ import { c } from './choices.js'
 
 export const MODELS = [
 	{ id: 'Auto', series: 'Auto', label: 'Auto Detect' },
-	{ id: 'AW-HE2', series: 'AW-HE2', label: 'AW-HE2' },
+	{ id: 'AW-HE2', series: 'HE2', label: 'AW-HE2' },
+	{ id: 'AW-HE20', series: 'UE20', label: 'AW-HE20' },
 	{ id: 'AW-HE35', series: 'HE40', label: 'AW-HE35' },
-	{ id: 'AW-HE38', series: 'HE40', label: 'AW-HE48' },
+	{ id: 'AW-HE38', series: 'HE40', label: 'AW-HE38' },
 	{ id: 'AW-HE40', series: 'HE40', label: 'AW-HE40' },
 	{ id: 'AW-HE42', series: 'HE42', label: 'AW-HE42' },
 	{ id: 'AW-HE48', series: 'HE40', label: 'AW-HE48' },
-	{ id: 'AW-HE50', series: 'AW-HE50', label: 'AW-HE50' },
+	{ id: 'AW-HE50', series: 'HE50', label: 'AW-HE50' },
 	{ id: 'AW-HE58', series: 'HE40', label: 'AW-HE58' },
-	{ id: 'AW-HE60', series: 'AW-HE60', label: 'AW-HE60' },
+	{ id: 'AW-HE60', series: 'HE60', label: 'AW-HE60' },
 	{ id: 'AW-HE65', series: 'HE40', label: 'AW-HE65' },
 	{ id: 'AW-HE68', series: 'HE42', label: 'AW-HE68' },
 	{ id: 'AW-HE70', series: 'HE40', label: 'AW-HE70' },
 	{ id: 'AW-HE75', series: 'HE42', label: 'AW-HE75' },
-	{ id: 'AW-HE120', series: 'AW-HE120', label: 'AW-HE120' },
-	{ id: 'AW-HE130', series: 'AW-HE130', label: 'AW-HE130' },
-	{ id: 'AW-HR140', series: 'AW-HR140', label: 'AW-HR140' },
+	{ id: 'AW-HE120', series: 'HE120', label: 'AW-HE120' },
+	{ id: 'AW-HE130', series: 'HE130', label: 'AW-HE130' },
+	{ id: 'AW-HE145', series: 'UE150', label: 'AW-HE145' },
 	{ id: 'AW-HN38', series: 'HE40', label: 'AW-HN38' },
 	{ id: 'AW-HN40', series: 'HE40', label: 'AW-HN40' },
 	{ id: 'AW-HN65', series: 'HE40', label: 'AW-HN65' },
-	{ id: 'AW-HN70', series: 'HE40', label: 'AW-HN70' },
-	{ id: 'AW-UE4', series: 'AW-UE4', label: 'AW-UE4' },
+	{ id: 'AW-HN130', series: 'HE130', label: 'AW-HN130' },
+	{ id: 'AW-HR140', series: 'HR140', label: 'AW-HR140' },
+	{ id: 'AW-UE4', series: 'UE4', label: 'AW-UE4' },
+	{ id: 'AW-UE20', series: 'UE20', label: 'AW-UE20' },
+	{ id: 'AW-UE40', series: 'UE80', label: 'AW-UE40' },
+	{ id: 'AW-UE50', series: 'UE80', label: 'AW-UE50' },
 	{ id: 'AW-UE63', series: 'UE70', label: 'AW-UE63' },
 	{ id: 'AW-UE65', series: 'UE70', label: 'AW-UE65' },
 	{ id: 'AW-UE70', series: 'UE70', label: 'AW-UE70' },
+	{ id: 'AW-UE80', series: 'UE80', label: 'AW-UE80' },
 	{ id: 'AW-UE100', series: 'UE150', label: 'AW-UE100' },
 	{ id: 'AW-UE150', series: 'UE150', label: 'AW-UE150' },
 	{ id: 'AW-UE155', series: 'UE150', label: 'AW-UE155' },
+	{ id: 'AW-UE160', series: 'UE160', label: 'AW-UE160' },
 	{ id: 'AW-UN70', series: 'UE70', label: 'AW-UN70' },
 	{ id: 'AW-UN145', series: 'UE150', label: 'AW-UN145' },
-	{ id: 'AW-HEF5', series: 'AW-HEF5', label: 'AW-HEF5' },
-	{ id: 'AW-SFU01', series: 'AW-SFU01', label: 'AW-SFU01' },
-	{ id: 'AK-UB300', series: 'AK-UB300', label: 'AK-UB300' },
+	{ id: 'AW-UR100', series: 'UE150', label: 'AW-UR100' },
+	{ id: 'AK-UB300', series: 'UB300', label: 'AK-UB300' },
 	{ id: 'AG-CX350', series: 'CX350', label: 'AG-CX350' },
 	{ id: 'AG-CX200', series: 'CX350', label: 'AG-CX200' },
 	{ id: 'AJ-UPX360', series: 'CX350', label: 'AJ-UPX360' },
@@ -44,20 +50,21 @@ export const MODELS = [
 
 // list of all Series:
 // Other
+// HE2
 // HE40
 // HE42
+// HE50
+// HE60
+// HE120
+// HE130
+// UE20
 // UE70
+// UE80
 // UE150
-// AW-HE2
-// AW-HE50
-// AW-HE60
-// AW-HE120
-// AW-HE130
-// AW-HR140
-// AW-HEF5
-// AW-UE4
-// AW-SHU01
-// AK-UB300
+// UE160
+// HR140
+// UE4
+// UB300
 // CX350
 
 export const SERIES_SPECS = [
@@ -101,8 +108,8 @@ export const SERIES_SPECS = [
 			OTAF: true, // Has One Touch Auto Focus Support (OSE:69:1)
 			iris: true, // Has Iris Support (manual and auto) (Ixx)
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_OTHER() }, // Has Gain Support
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_OTHER }, // Has Shutter Support
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_OTHER() }, // Has Pedistal Support
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_OTHER() }, // Has Shutter Support
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_OTHER() }, // Has Pedestal Support
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_OTHER() }, // Has ND Filter Support
 			preset: true, // Can Save and Recall Presets (Mxxx or Rxxx)
 			speedPset: true, // Has Preset Recall Speed Control (UPVSxx)
@@ -209,10 +216,10 @@ export const SERIES_SPECS = [
 			OAF: true,
 			OTAF: true,
 			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE42() },
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE40 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE42() },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE42() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_HE42() },
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3A },
 			preset: true,
 			speedPset: true,
 			timePset: false,
@@ -263,10 +270,10 @@ export const SERIES_SPECS = [
 			OAF: true,
 			OTAF: true,
 			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE70() },
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE40 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_UE70() },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_UE70() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_UE70 },
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3A },
 			preset: true,
 			speedPset: true,
 			timePset: false,
@@ -319,10 +326,10 @@ export const SERIES_SPECS = [
 			OAF: true,
 			OTAF: true,
 			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE150() },
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE150 },
 			shut: false, // TODO: Add it's own shutter "OSJ:06:"
-			ped: false, // TODO: Add it's own Pedestal "OSJ:0F:"
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_UE150() },
+			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_UE150() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: true,
 			speedPset: true,
 			timePset: true,
@@ -338,8 +345,68 @@ export const SERIES_SPECS = [
 	},
 
 	{
+		// Specific for the UE150 Series
+		id: 'UE160',
+		variables: {
+			version: true,
+			error: true,
+			ins: true,
+			power: true,
+			colorbar: true,
+			tally: true,
+			tally2: true,
+			tally3: true,
+			OAF: true,
+			iris: true,
+			gainValue: true,
+			preset: true,
+			whiteBalance: true,
+			colorTemperature: false,
+		},
+		feedbacks: {
+			powerState: true,
+			colorbarState: true,
+			tallyState: true,
+			tally2State: true,
+			tally3State: true,
+			insState: true,
+			autoFocus: true,
+			autoIris: true,
+			whiteBalance: true,
+			preset: true,
+		},
+		actions: {
+			panTilt: true,
+			ptSpeed: true,
+			zoom: true,
+			zSpeed: true,
+			focus: true,
+			fSpeed: true,
+			OAF: true,
+			OTAF: true,
+			iris: true,
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE160 },
+			shut: false, // TODO: Add it's own shutter "OSJ:06:"
+			ped: false, // TODO: Add it's own Pedestal "OSJ:0F:"
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
+			preset: true,
+			speedPset: true,
+			timePset: true,
+			power: true,
+			ins: true,
+			colorbar: true,
+			tally: true,
+			tally2: true,
+			tally3: true,
+			sdCard: false,
+			whiteBalance: true,
+			colorTemperature: false,
+		},
+	},
+
+	{
 		// Specific for the AW-HE2 Camera
-		id: 'AW-HE2', // A lot has been turned off since it will need custop setups for this camera, can be added if requested
+		id: 'HE2', // A lot has been turned off since it will need custop setups for this camera, can be added if requested
 		variables: {
 			version: true,
 			error: true,
@@ -393,7 +460,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-HE50 Camera
-		id: 'AW-HE50',
+		id: 'HE50',
 		variables: {
 			version: true,
 			error: true,
@@ -430,7 +497,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE50 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE50 },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE50() },
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: false,
 			preset: true,
 			speedPset: true,
@@ -447,7 +514,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-HE60 Camera
-		id: 'AW-HE60',
+		id: 'HE60',
 		variables: {
 			version: true,
 			error: true,
@@ -482,9 +549,9 @@ export const SERIES_SPECS = [
 			OAF: true,
 			OTAF: true,
 			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE60() },
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE50 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE60() },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE60() },
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: false,
 			preset: true,
 			speedPset: true,
@@ -501,7 +568,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-HE120 Camera
-		id: 'AW-HE120',
+		id: 'HE120',
 		variables: {
 			version: true,
 			error: true,
@@ -539,7 +606,7 @@ export const SERIES_SPECS = [
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE120 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE120 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE120() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_HE120 },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: true,
 			speedPset: true,
 			timePset: false,
@@ -555,7 +622,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-HE130 Camera
-		id: 'AW-HE130',
+		id: 'HE130',
 		variables: {
 			version: true,
 			error: true,
@@ -592,8 +659,8 @@ export const SERIES_SPECS = [
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE130 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE130 },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE130() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_HE130 },
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE120() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_2 },
 			preset: true,
 			speedPset: true,
 			timePset: false,
@@ -609,7 +676,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-HR140 Camera
-		id: 'AW-HR140',
+		id: 'HR140',
 		variables: {
 			version: true,
 			error: true,
@@ -646,62 +713,8 @@ export const SERIES_SPECS = [
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HR140 },
 			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HR140() },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HR140() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_HR140() },
-			preset: true,
-			speedPset: true,
-			timePset: false,
-			power: true,
-			colorbar: true,
-			tally: true,
-			ins: true,
-			sdCard: false,
-			whiteBalance: true,
-			colorTemperature: false,
-		},
-	},
-
-	{
-		// Specific for the AW-HEF5 Camera
-		id: 'AW-HEF5',
-		variables: {
-			version: true,
-			error: true,
-			ins: true,
-			power: true,
-			colorbar: true,
-			tally: true,
-			OAF: true,
-			iris: true,
-			gainValue: true,
-			preset: true,
-			whiteBalance: true,
-			colorTemperature: false,
-		},
-		feedbacks: {
-			powerState: true,
-			colorbarState: true,
-			tallyState: true,
-			insState: true,
-			autoFocus: true,
-			autoIris: true,
-			whiteBalance: true,
-			preset: true,
-		},
-		actions: {
-			panTilt: true,
-			ptSpeed: true,
-			zoom: true,
-			zSpeed: true,
-			focus: true,
-			fSpeed: true,
-			OAF: true,
-			OTAF: true,
-			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE50 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE50 },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE50() },
-			filter: true,
+			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE120() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_2 },
 			preset: true,
 			speedPset: true,
 			timePset: false,
@@ -717,7 +730,7 @@ export const SERIES_SPECS = [
 
 	{
 		// Specific for the AW-UE4 Camera
-		id: 'AW-UE4', // A lot has been turned off since it will need custop setups for this camera, can be added if requested
+		id: 'UE4', // A lot has been turned off since it will need custop setups for this camera, can be added if requested
 		variables: {
 			version: false,
 			error: true,
@@ -770,62 +783,8 @@ export const SERIES_SPECS = [
 	},
 
 	{
-		// Specific for the AW-SHU01 Camera
-		id: 'AW-SHU01',
-		variables: {
-			version: true,
-			error: true,
-			ins: true,
-			power: true,
-			colorbar: true,
-			tally: true,
-			OAF: true,
-			iris: true,
-			gainValue: true,
-			preset: true,
-			whiteBalance: true,
-			colorTemperature: false,
-		},
-		feedbacks: {
-			powerState: true,
-			colorbarState: true,
-			tallyState: true,
-			insState: true,
-			autoFocus: true,
-			autoIris: true,
-			whiteBalance: true,
-			preset: true,
-		},
-		actions: {
-			panTilt: true,
-			ptSpeed: true,
-			zoom: true,
-			zSpeed: true,
-			focus: true,
-			fSpeed: true,
-			OAF: true,
-			OTAF: true,
-			iris: true,
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE70() },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_UE70() },
-			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_UE70() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_UE70 },
-			preset: true,
-			speedPset: true,
-			timePset: false,
-			power: true,
-			colorbar: true,
-			tally: true,
-			ins: true,
-			sdCard: false,
-			whiteBalance: true,
-			colorTemperature: false,
-		},
-	},
-
-	{
 		// Specific for the AK-UB300 Camera
-		id: 'AK-UB300',
+		id: 'UB300',
 		variables: {
 			version: false,
 			error: true,
@@ -846,7 +805,7 @@ export const SERIES_SPECS = [
 			insState: false,
 			autoFocus: false,
 			autoIris: false,
-			whiteBalance: true,
+			whiteBalance: false,
 			preset: false,
 		},
 		actions: {
@@ -861,8 +820,8 @@ export const SERIES_SPECS = [
 			iris: false,
 			gain: { cmd: 'OGS:', dropdown: c.CHOICES_GAIN_UB300 },
 			shut: { cmd: 'OSG:5D:', dropdown: c.CHOICES_SHUTTER_UB300 },
-			ped: false, // TODO: Add UB300 Pedestal "OSG:4A:"
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_UB300 },
+			ped: { cmd: 'OSG:4A:', dropdown: c.CHOICES_PEDESTAL_UB300() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: false,
 			speedPset: false,
 			timePset: false,
@@ -920,8 +879,8 @@ export const SERIES_SPECS = [
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_CX350 },
 			shut: false,
-			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_CX350() },
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_CX350() },
+			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_UE150() },
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: false,
 			speedPset: false,
 			timePset: false,

--- a/src/models.js
+++ b/src/models.js
@@ -76,6 +76,7 @@ export const SERIES_SPECS = [
 			iris: true, // Has Auto Iris (d30 or d31)
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,  // Has White Balance (OAW:x)
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -86,6 +87,7 @@ export const SERIES_SPECS = [
 			insState: true, // Install position (iNS0 or iNS1)
 			autoFocus: true, // Has Auto Focus (OAF:1 or OAF:0)
 			autoIris: true, // Has Auto Iris (d30 or d31)
+			whiteBalance: true,  // Has White Balance (OAW:x)
 			preset: true,
 		},
 		actions: {
@@ -111,6 +113,7 @@ export const SERIES_SPECS = [
 			tally2: true, // Has Green Tally Light Control (TLG:1 or TLG:0)
 			ins: true, // Has Install Position Control (INSx)
 			sdCard: true, // Has SD Card Recording Control (sdctrl?save=start or sdctrl?save=end)
+			whiteBalance: true,  // Has White Balance Control (OAW:x)
 			colorTemperature: false, // Setting Color temperature OSD:B1:A8h
 		},
 	},
@@ -129,6 +132,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -138,6 +142,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -162,6 +167,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -180,6 +186,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -189,6 +196,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -213,6 +221,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -231,6 +240,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -240,6 +250,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -264,6 +275,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -283,6 +295,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -293,6 +306,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -318,6 +332,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			tally2: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -336,6 +351,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -345,6 +361,7 @@ export const SERIES_SPECS = [
 			insState: false,
 			autoFocus: false,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -369,6 +386,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: false,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -387,6 +405,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -396,6 +415,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -420,6 +440,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -438,6 +459,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -447,6 +469,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -471,6 +494,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -489,6 +513,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -498,6 +523,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -522,6 +548,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -540,6 +567,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: true,
 		},
 		feedbacks: {
@@ -549,6 +577,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -573,7 +602,8 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			colorTemperature: { cmd: 'OSD:B1:', dropdown: c.CHOICES_COLOR_TEMPERATURE_HE130},
+			whiteBalance: true,
+			colorTemperature: { cmd: 'OSD:B1:', dropdown: c.CHOICES_COLOR_TEMPERATURE_HE130 },
 		},
 	},
 
@@ -591,6 +621,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -600,6 +631,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -624,6 +656,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -642,6 +675,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -651,6 +685,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -675,6 +710,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -693,6 +729,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -702,6 +739,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: false,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -726,6 +764,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -744,6 +783,7 @@ export const SERIES_SPECS = [
 			iris: true,
 			gainValue: true,
 			preset: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -753,6 +793,7 @@ export const SERIES_SPECS = [
 			insState: true,
 			autoFocus: true,
 			autoIris: true,
+			whiteBalance: true,
 			preset: true,
 		},
 		actions: {
@@ -777,6 +818,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},
@@ -795,6 +837,7 @@ export const SERIES_SPECS = [
 			OAF: false,
 			iris: false,
 			preset: false,
+			whiteBalance: false,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -803,6 +846,7 @@ export const SERIES_SPECS = [
 			insState: false,
 			autoFocus: false,
 			autoIris: false,
+			whiteBalance: true,
 			preset: false,
 		},
 		actions: {
@@ -828,6 +872,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			tally2: true,
 			sdCard: false,
+			whiteBalance: false,
 			colorTemperature: false,
 		},
 	},
@@ -848,6 +893,7 @@ export const SERIES_SPECS = [
 			iris: false,
 			gainValue: false,
 			preset: false,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -859,6 +905,7 @@ export const SERIES_SPECS = [
 			insState: false,
 			autoFocus: false,
 			autoIris: false,
+			whiteBalance: false,
 			preset: false,			
 		},
 		actions: {
@@ -884,6 +931,7 @@ export const SERIES_SPECS = [
 			tally2: true,
 			ins: false,
 			sdCard: true,
+			whiteBalance: true,
 			colorTemperature: false,
 		},
 	},

--- a/src/models.js
+++ b/src/models.js
@@ -824,7 +824,7 @@ export const SERIES_SPECS = [
 			OAF: true, // Has Auto Focus Support (D10 or D11)
 			OTAF: true, // Has One Touch Auto Focus Support (OSE:69:1)
 			iris: true, // Has Iris Support (manual and auto) (Ixx)
-			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_CX350() },
+			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_CX350 },
 			shut: false,
 			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_CX350() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_CX350() },

--- a/src/models.js
+++ b/src/models.js
@@ -108,9 +108,9 @@ export const SERIES_SPECS = [
 			OTAF: true, // Has One Touch Auto Focus Support (OSE:69:1)
 			iris: true, // Has Iris Support (manual and auto) (Ixx)
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_OTHER() }, // Has Gain Support
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_OTHER() }, // Has Shutter Support
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_OTHER }, // Has Shutter Support
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_OTHER() }, // Has Pedestal Support
-			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_OTHER() }, // Has ND Filter Support
+			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_OTHER }, // Has ND Filter Support
 			preset: true, // Can Save and Recall Presets (Mxxx or Rxxx)
 			speedPset: true, // Has Preset Recall Speed Control (UPVSxx)
 			timePset: true, // Has Preset Recall Time Control (UPVSxx or OSJ:29:xx)
@@ -120,7 +120,7 @@ export const SERIES_SPECS = [
 			tally2: true, // Has Green Tally Light Control (TLG:1 or TLG:0)
 			ins: true, // Has Install Position Control (INSx)
 			sdCard: true, // Has SD Card Recording Control (sdctrl?save=start or sdctrl?save=end)
-			whiteBalance: true,  // Has White Balance Control (OAW:x)
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },  // Has White Balance Control (OAW:x)
 			colorTemperature: false, // Setting Color temperature OSD:B1:A8h
 		},
 	},
@@ -163,7 +163,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE40 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40() },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: false,
 			preset: true,
@@ -174,7 +174,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -217,7 +217,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE40 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE42() },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3A },
 			preset: true,
@@ -228,7 +228,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -271,7 +271,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE40 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_UE70() },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3A },
 			preset: true,
@@ -282,7 +282,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: true,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -327,7 +327,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE150 },
-			shut: false, // TODO: Add it's own shutter "OSJ:06:"
+			shut: { cmd: 'OSJ:06:', dropdown: c.CHOICES_SHUTTER_UE150() },
 			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_UE150() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: true,
@@ -339,7 +339,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			tally2: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -386,8 +386,8 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_UE160 },
-			shut: false, // TODO: Add it's own shutter "OSJ:06:"
-			ped: false, // TODO: Add it's own Pedestal "OSJ:0F:"
+			shut: { cmd: 'OSJ:06:', dropdown: c.CHOICES_SHUTTER_UE150() },
+			ped: { cmd: 'OSJ:0F:', dropdown: c.CHOICES_PEDESTAL_UE150() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_3 },
 			preset: true,
 			speedPset: true,
@@ -399,7 +399,7 @@ export const SERIES_SPECS = [
 			tally2: true,
 			tally3: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -453,7 +453,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: false,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -496,7 +496,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE50 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE50 },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: false,
 			preset: true,
@@ -507,7 +507,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -550,7 +550,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HE50 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE60() },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE40 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE40() },
 			filter: false,
 			preset: true,
@@ -561,7 +561,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -615,7 +615,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -669,7 +669,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: { cmd: 'OSD:B1:', dropdown: c.CHOICES_COLOR_TEMPERATURE_HE130 },
 		},
 	},
@@ -712,7 +712,7 @@ export const SERIES_SPECS = [
 			OTAF: true,
 			iris: true,
 			gain: { cmd: 'OGU:', dropdown: c.CHOICES_GAIN_HR140 },
-			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HR140() },
+			shut: { cmd: 'OSH:', dropdown: c.CHOICES_SHUTTER_HE130 },
 			ped: { cmd: 'OTP:', dropdown: c.CHOICES_PEDESTAL_HE120() },
 			filter: { cmd: 'OFT:', dropdown: c.CHOICES_FILTER_2 },
 			preset: true,
@@ -723,7 +723,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -777,7 +777,7 @@ export const SERIES_SPECS = [
 			tally: true,
 			ins: true,
 			sdCard: false,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},
@@ -852,7 +852,7 @@ export const SERIES_SPECS = [
 			iris: false,
 			gainValue: false,
 			preset: false,
-			whiteBalance: true,
+			whiteBalance: false,
 			colorTemperature: false,
 		},
 		feedbacks: {
@@ -890,7 +890,7 @@ export const SERIES_SPECS = [
 			tally2: true,
 			ins: false,
 			sdCard: true,
-			whiteBalance: true,
+			whiteBalance: { dropdown: c.CHOICES_WB_SET },
 			colorTemperature: false,
 		},
 	},

--- a/src/presets.js
+++ b/src/presets.js
@@ -7,7 +7,12 @@ export function getPresetDefinitions(self) {
 
 	const colorWhite = combineRgb(255, 255, 255)
 	const colorRed = combineRgb(255, 0, 0)
-	const colorGreen = combineRgb(0, 255, 0)
+	const colorGreen = combineRgb(0, 204, 0)
+	const colorYellow = combineRgb(255, 255, 0)
+	const colorBlue = combineRgb(0, 51, 204)
+	const colorPurple = combineRgb(255, 0, 255)
+	const colorOrange = combineRgb(255, 102, 0)
+	const colorGrey = combineRgb(51, 51, 51)
 	const colorBlack = combineRgb(0, 0, 0)
 
 	const SERIES = getAndUpdateSeries(self)
@@ -2049,31 +2054,53 @@ export function getPresetDefinitions(self) {
 			],
 		}
 
-		for (let recall = 0; recall < 100; recall++) {
-			presets[`recall-preset-${recall}`] = {
+		for (let i = 0; i < 100; i++) {
+			presets[`recall-preset-${i}`] = {
 				type: 'button',
 				category: 'Recall Preset',
-				name: 'Recall Preset ' + parseInt(recall + 1),
+				name: 'Recall Preset ' + (i + 1).toString(),
 				style: {
-					text: 'Recall\\nPRESET\\n' + parseInt(recall + 1),
+					text: 'Recall\\nPRESET\\n' + (i + 1).toString(),
 					size: '14',
 					color: colorWhite,
 					bgcolor: colorBlack,
+				},
+				options: {
+					relativeDelay: true,
 				},
 				steps: [
 					{
 						down: [
 							{
-								actionId: 'recallPset',
+								actionId: 'savePset',
+								delay: 2000,
 								options: {
-									val: ('0' + recall.toString(10).toUpperCase()).substr(-2, 2),
+									val: i.toString(10).padStart(2, '0'),
 								},
 							},
 						],
-						up: [],
+						up: [
+							{
+								actionId: 'recallPset',
+								options: {
+									val: i.toString(10).padStart(2, '0'),
+								},
+							},
+						],
 					},
 				],
-				feedbacks: [],
+				feedbacks: [
+					{
+						feedbackId: 'presetComplete',
+						options: {
+							option: i.toString(10).padStart(2, '0'),
+						},
+						style: {
+							color: colorWhite,
+							bgcolor: colorBlue,
+						},
+					},
+				],
 			}
 		}
 	}

--- a/src/presets.js
+++ b/src/presets.js
@@ -1700,7 +1700,7 @@ export function getPresetDefinitions(self) {
 				category: 'Save Preset',
 				name: 'Save Preset ' + parseInt(save + 1),
 				style: {
-					text: 'SAVE\\nPSET\\n' + parseInt(save + 1),
+					text: 'SAVE\\nPRESET\\n' + parseInt(save + 1),
 					size: '14',
 					color: colorWhite,
 					bgcolor: colorBlack,
@@ -2055,7 +2055,7 @@ export function getPresetDefinitions(self) {
 				category: 'Recall Preset',
 				name: 'Recall Preset ' + parseInt(recall + 1),
 				style: {
-					text: 'Recall\\nPSET\\n' + parseInt(recall + 1),
+					text: 'Recall\\nPRESET\\n' + parseInt(recall + 1),
 					size: '14',
 					color: colorWhite,
 					bgcolor: colorBlack,

--- a/src/presets.js
+++ b/src/presets.js
@@ -1344,6 +1344,78 @@ export function getPresetDefinitions(self) {
 		}
 	}
 
+	if (seriesActions.colorbar) {
+		presets['system-colorbar-off'] = {
+			type: 'button',
+			category: 'System',
+			name: 'Color Bar Off',
+			style: {
+				text: 'Color Bar\\nOFF',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
+			},
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'colorbarOff',
+							options: {},
+						},
+					],
+					up: [],
+				},
+			],
+			feedbacks: [
+				{
+					feedbackId: 'colorbarState',
+					options: {
+						option: '0',
+					},
+					style: {
+						color: colorWhite,
+						bgcolor: colorRed,
+					},
+				},
+			],
+		}
+
+		presets['system-colorbar-on'] = {
+			type: 'button',
+			category: 'System',
+			name: 'Color Bar On',
+			style: {
+				text: 'Color Bar\\nON',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
+			},
+			steps: [
+				{
+					down: [
+						{
+							actionId: 'colorbarOn',
+							options: {},
+						},
+					],
+					up: [],
+				},
+			],
+			feedbacks: [
+				{
+					feedbackId: 'colorbarState',
+					options: {
+						option: '1',
+					},
+					style: {
+						color: colorWhite,
+						bgcolor: colorRed,
+					},
+				},
+			],
+		}
+	}
+
 	if (seriesActions.tally) {
 		presets['system-tally-off'] = {
 			type: 'button',

--- a/src/presets.js
+++ b/src/presets.js
@@ -981,7 +981,7 @@ export function getPresetDefinitions(self) {
 						{
 							actionId: 'irisM',
 							options: {
-								bol: 1,
+								bol: 0,
 							},
 						},
 					],
@@ -1018,7 +1018,7 @@ export function getPresetDefinitions(self) {
 						{
 							actionId: 'irisM',
 							options: {
-								bol: 0,
+								bol: 1,
 							},
 						},
 					],

--- a/src/presets.js
+++ b/src/presets.js
@@ -5,10 +5,10 @@ import ICONS from './icons.js';
 export function getPresetDefinitions(self) {
 	const presets = {}
 
-	const foregroundColor = combineRgb(255, 255, 255) // White
-	const backgroundColorRed = combineRgb(255, 0, 0) // Red
-	const backgroundColorGreen = combineRgb(0, 255, 0) // Green
-	const backgroundColorOrange = combineRgb(255, 102, 0) // Orange
+	const colorWhite = combineRgb(255, 255, 255)
+	const colorRed = combineRgb(255, 0, 0)
+	const colorGreen = combineRgb(0, 255, 0)
+	const colorBlack = combineRgb(0, 0, 0)
 
 	const SERIES = getAndUpdateSeries(self)
 	const seriesActions = SERIES.actions
@@ -28,8 +28,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.UP,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -59,8 +59,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.DOWN,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -90,8 +90,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.LEFT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -121,8 +121,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.RIGHT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -152,8 +152,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.UP_RIGHT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -183,8 +183,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.UP_LEFT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -214,8 +214,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.DOWN_LEFT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -245,8 +245,8 @@ export function getPresetDefinitions(self) {
 				png64: ICONS.DOWN_RIGHT,
 				pngalignment: 'center:center',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -274,8 +274,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'HOME',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -300,8 +300,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SPEED\\nUP\\n$(Panasonic-PTZ:ptSpeedVar)',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -324,8 +324,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SPEED\\nDOWN\\n$(Panasonic-PTZ:ptSpeedVar)',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -348,8 +348,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SET\\nSPEED\\nHIGH',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -374,8 +374,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SET\\nSPEED\\nMID',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -400,8 +400,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SET\\nSPEED\\nLOW',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -432,8 +432,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nIN',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -461,8 +461,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nOUT',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -492,8 +492,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nSPEED\\nUP\\n$(Panasonic-PTZ:zSpeedVar)',
 				size: '7',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -516,8 +516,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nSPEED\\nDOWN\\n$(Panasonic-PTZ:zSpeedVar)',
 				size: '7',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -540,8 +540,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nSPEED\\nHIGH',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -566,8 +566,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nSPEED\\nMID',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -592,8 +592,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'ZOOM\\nSPEED\\nLOW',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -620,8 +620,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nNEAR',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -649,8 +649,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nFAR',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -680,8 +680,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nSPEED\\nUP\\n$(Panasonic-PTZ:fSpeedVar)',
 				size: '7',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -704,8 +704,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nSPEED\\nDOWN\\n$(Panasonic-PTZ:fSpeedVar)',
 				size: '7',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -727,8 +727,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nSPEED\\nHIGH',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -753,8 +753,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nSPEED\\nMID',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -779,8 +779,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'FOCUS\\nSPEED\\nLOW',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -807,8 +807,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'MANUAL\\nFOCUS',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -830,8 +830,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -844,8 +844,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'AUTO\\nFOCUS',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -867,8 +867,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -881,8 +881,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'OTAF\\nFOCUS',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -904,8 +904,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -924,8 +924,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'IRIS\\nUP',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -948,8 +948,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'IRIS\\nDOWN',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -972,8 +972,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'MANUAL\\nIRIS',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -995,8 +995,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1009,8 +1009,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'AUTO\\nIRIS',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1032,8 +1032,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1048,8 +1048,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'GAIN\\nUP',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1072,8 +1072,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'GAIN\\nDOWN',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1098,8 +1098,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Shut\\nUP',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1122,8 +1122,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Shut\\nDOWN',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1148,8 +1148,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Pedestal\\nUP',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1172,8 +1172,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Pedestal\\nDOWN',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1194,12 +1194,12 @@ export function getPresetDefinitions(self) {
 		presets['exposure-filter-up'] = {
 			type: 'button',
 			category: 'Exposure',
-			name: 'Filter Up',
+			name: 'ND Filter Up',
 			style: {
-				text: 'Filter\\nUP',
+				text: 'ND Filter\\nUP',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1218,12 +1218,12 @@ export function getPresetDefinitions(self) {
 		presets['exposure-filter-down'] = {
 			type: 'button',
 			category: 'Exposure',
-			name: 'Filter Down',
+			name: 'ND Filter Down',
 			style: {
-				text: 'Filter\\nDOWN',
+				text: 'ND Filter\\nDOWN',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1245,10 +1245,10 @@ export function getPresetDefinitions(self) {
 				category: 'Exposure',
 				name: 'ND Filter Set ' + seriesActions.filter.dropdown[x].label,
 				style: {
-					text: 'FILTER\\nSET\\n' + seriesActions.filter.dropdown[x].label,
+					text: 'ND FILTER\\nSET\\n' + seriesActions.filter.dropdown[x].label,
 					size: '14',
-					color: 16777215,
-					bgcolor: combineRgb(0, 0, 0),
+					color: colorWhite,
+					bgcolor: colorBlack,
 				},
 				steps: [
 					{
@@ -1280,8 +1280,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Power\\nOFF',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1301,8 +1301,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1315,8 +1315,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Power\\nON',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1336,8 +1336,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1350,10 +1350,10 @@ export function getPresetDefinitions(self) {
 			category: 'System',
 			name: 'Red Tally Off',
 			style: {
-				text: 'Tally\\nOFF',
-				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				text: 'Red Tally\\nOFF',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1373,8 +1373,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1385,10 +1385,10 @@ export function getPresetDefinitions(self) {
 			category: 'System',
 			name: 'Red Tally On',
 			style: {
-				text: 'Tally\\nON',
-				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				text: 'Red Tally\\nON',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1408,8 +1408,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1422,10 +1422,10 @@ export function getPresetDefinitions(self) {
 			category: 'System',
 			name: 'Green Tally Off',
 			style: {
-				text: 'Tally\\nOFF',
-				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				text: 'Green Tally\\nOFF',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1445,8 +1445,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorGreen,
+						color: colorWhite,
+						bgcolor: colorGreen,
 					},
 				},
 			],
@@ -1457,10 +1457,10 @@ export function getPresetDefinitions(self) {
 			category: 'System',
 			name: 'Green Tally On',
 			style: {
-				text: 'Tally\\nON',
-				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				text: 'Green Tally\\nON',
+				size: '14',
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1480,8 +1480,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorGreen,
+						color: colorWhite,
+						bgcolor: colorGreen,
 					},
 				},
 			],
@@ -1496,8 +1496,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'INS\\nDesk',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1519,8 +1519,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1533,8 +1533,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'INS\\nHang',
 				size: '18',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1556,8 +1556,8 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1572,8 +1572,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SD Card\\nRecording\\nStart',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1598,8 +1598,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'SD Card\\nRecording\\nStop',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1630,8 +1630,8 @@ export function getPresetDefinitions(self) {
 				style: {
 					text: 'SAVE\\nPSET\\n' + parseInt(save + 1),
 					size: '14',
-					color: 16777215,
-					bgcolor: combineRgb(0, 0, 0),
+					color: colorWhite,
+					bgcolor: colorBlack,
 				},
 				steps: [
 					{
@@ -1659,8 +1659,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'PRESET\\nMODE\\nSPEED',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1685,8 +1685,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'PRESET\\nMODE\\nTIME',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1713,8 +1713,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nSPEED\\nHIGH',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1739,8 +1739,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nSPEED\\nMID',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1765,8 +1765,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nSPEED\\nLOW',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1793,8 +1793,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nTIME\\n5 Sec',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1819,8 +1819,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nTIME\\n10 Sec',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1845,8 +1845,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'RECALL\\nTIME\\n30 Sec',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1873,8 +1873,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Preset\\nMode A',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1896,8 +1896,8 @@ export function getPresetDefinitions(self) {
 						option: '0',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
@@ -1910,8 +1910,8 @@ export function getPresetDefinitions(self) {
 			style: {
 				text: 'Preset\\nMode B',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
@@ -1933,76 +1933,76 @@ export function getPresetDefinitions(self) {
 						option: '1',
 					},
 					style: {
-						color: foregroundColor,
-						bgcolor: backgroundColorRed,
+						color: colorWhite,
+						bgcolor: colorRed,
 					},
 				},
 			],
 		}
-	}
 
-	presets['recall-preset-mode-c'] = {
-		type: 'button',
-		category: 'Recall Preset',
-		name: 'Preset Mode C',
-		style: {
-			text: 'Preset\\nMode C',
-			size: '14',
-			color: 16777215,
-			bgcolor: combineRgb(0, 0, 0),
-		},
-		steps: [
-			{
-				down: [
-					{
-						actionId: 'recallModePset',
-						options: {
-							val: '2',
-						},
-					},
-				],
-				up: [],
-			},
-		],
-		feedbacks: [
-			{
-				feedbackId: 'recallModePset',
-				options: {
-					option: '2',
-				},
-				style: {
-					color: foregroundColor,
-					bgcolor: backgroundColorRed,
-				},
-			},
-		],
-	}
-
-	for (let recall = 0; recall < 100; recall++) {
-		presets[`recall-preset-${recall}`] = {
+		presets['recall-preset-mode-c'] = {
 			type: 'button',
 			category: 'Recall Preset',
-			name: 'Recall Preset ' + parseInt(recall + 1),
+			name: 'Preset Mode C',
 			style: {
-				text: 'Recall\\nPSET\\n' + parseInt(recall + 1),
+				text: 'Preset\\nMode C',
 				size: '14',
-				color: 16777215,
-				bgcolor: combineRgb(0, 0, 0),
+				color: colorWhite,
+				bgcolor: colorBlack,
 			},
 			steps: [
 				{
 					down: [
 						{
-							actionId: 'recallPset',
+							actionId: 'recallModePset',
 							options: {
-								val: ('0' + recall.toString(10).toUpperCase()).substr(-2, 2),
+								val: '2',
 							},
 						},
 					],
 					up: [],
 				},
 			],
-			feedbacks: [],
+			feedbacks: [
+				{
+					feedbackId: 'recallModePset',
+					options: {
+						option: '2',
+					},
+					style: {
+						color: colorWhite,
+						bgcolor: colorRed,
+					},
+				},
+			],
+		}
+
+		for (let recall = 0; recall < 100; recall++) {
+			presets[`recall-preset-${recall}`] = {
+				type: 'button',
+				category: 'Recall Preset',
+				name: 'Recall Preset ' + parseInt(recall + 1),
+				style: {
+					text: 'Recall\\nPSET\\n' + parseInt(recall + 1),
+					size: '14',
+					color: colorWhite,
+					bgcolor: colorBlack,
+				},
+				steps: [
+					{
+						down: [
+							{
+								actionId: 'recallPset',
+								options: {
+									val: ('0' + recall.toString(10).toUpperCase()).substr(-2, 2),
+								},
+							},
+						],
+						up: [],
+					},
+				],
+				feedbacks: [],
+			}
 		}
 	}
 

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,4 +1,5 @@
 import { getAndUpdateSeries } from './common.js'
+import { CHOICE_WB_GET } from './choices.js'
 
 // ##########################
 // #### Define Variables ####
@@ -41,6 +42,9 @@ export function setVariables(self) {
 	if (SERIES.variables.OAF) {
 		variables.push({ variableId: 'OAF', name: 'Auto Focus Mode' })
 	}
+	if (SERIES.variables.whiteBalance) {
+		variables.push({ variableId: 'whiteBalance', name: 'White Balance Mode' })
+	}
 	if (SERIES.variables.colorTemperature) {
 		variables.push({ variableId: 'colorTemperature', name: 'Color Temperature' })
 	}
@@ -72,9 +76,12 @@ export function checkVariables(self) {
 		? SERIES.actions.gain.dropdown.find((GAIN) => GAIN.id == self.data.gainValue)
 		: null
 
-
 	const colorTemperature = SERIES.actions.colorTemperature
 		? SERIES.actions.colorTemperature.dropdown.find((colorTemperature) => colorTemperature.id == self.data.colorTemperature)
+		: null
+
+	const whiteBalance = SERIES.actions.whiteBalance
+		? CHOICE_WB_GET.find((whiteBalance) => whiteBalance.id == self.data.whiteBalance)
 		: null
 
 
@@ -90,6 +97,7 @@ export function checkVariables(self) {
 		tally: self.data.tally,
 		tally2: self.data.tally2,
 		OAF: self.data.oaf,
+		whiteBalance: whiteBalance?.label,
 		colorTemperature: colorTemperature?.label,
 		irisMode: self.data.irisMode,
 		gainValue: gainValue?.label,

--- a/src/variables.js
+++ b/src/variables.js
@@ -29,6 +29,9 @@ export function setVariables(self) {
 	if (SERIES.variables.power) {
 		variables.push({ variableId: 'power', name: 'Power ON/OFF' })
 	}
+	if (SERIES.variables.colorbar) {
+		variables.push({ variableId: 'colorbar', name: 'Color Bar ENABLED' })
+	}
 	if (SERIES.variables.tally) {
 		variables.push({ variableId: 'tally', name: 'Red Tally ON/OFF' })
 	}
@@ -82,6 +85,7 @@ export function checkVariables(self) {
 		error: self.data.error,
 		ins: self.data.ins,
 		power: self.data.power,
+		colorbar: self.data.colorbar,
 		tally: self.data.tally,
 		tally2: self.data.tally2,
 		OAF: self.data.oaf,

--- a/src/variables.js
+++ b/src/variables.js
@@ -52,6 +52,7 @@ export function setVariables(self) {
 	}
 	if (SERIES.variables.preset) {
 		variables.push({ variableId: 'presetMode', name: 'Preset Mode' })
+		variables.push({ variableId: 'lastPresetCompleted', name: 'Last Preset Completed' })
 	}
 	variables.push({ variableId: 'ptSpeedVar', name: 'Pan/Tilt Speed' })
 	variables.push({ variableId: 'pSpeedVar', name: 'Pan Speed' })
@@ -98,5 +99,6 @@ export function checkVariables(self) {
 		tSpeedVar: self.tSpeed,
 		zSpeedVar: self.zSpeed,
 		fSpeedVar: self.fSpeed,
+		lastPresetCompleted: self.data.lastPresetCompleted,
 	})
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -62,9 +62,13 @@ export function setVariables(self) {
 	variables.push({ variableId: 'tSpeedVar', name: 'Tilt Speed' })
 	variables.push({ variableId: 'zSpeedVar', name: 'Zoom Speed' })
 	variables.push({ variableId: 'fSpeedVar', name: 'Focus Speed' })
-	variables.push({ variableId: 'zoomPosition', name: 'Zoom Position' })
-	variables.push({ variableId: 'focusPosition', name: 'Focus Position' })
-	variables.push({ variableId: 'irisPosition', name: 'Iris Position' })
+	variables.push({ variableId: 'zoomPosition', name: 'Zoom Position %' })
+	variables.push({ variableId: 'focusPosition', name: 'Focus Position %' })
+	variables.push({ variableId: 'irisPosition', name: 'Iris Position %' })
+	variables.push({ variableId: 'zoomPositionBar', name: 'Zoom Position' })
+	variables.push({ variableId: 'focusPositionBar', name: 'Focus Position' })
+	variables.push({ variableId: 'irisPositionBar', name: 'Iris Position' })
+	variables.push({ variableId: 'irisF', name: 'Iris F No' })
 	return variables
 }
 
@@ -86,6 +90,22 @@ export function checkVariables(self) {
 		? SERIES.actions.whiteBalance.dropdown.find((whiteBalance) => whiteBalance.id == self.data.whiteBalance)
 		: null
 
+	const progressBar = (pct, width = 20, start = '', end = '') => {
+		if (pct && pct >= 0 && pct <= 100) {
+			const flr = Math.floor(pct * width / 100)
+			return start + (".").repeat(flr) + ("|") + (".").repeat(width-flr) + end
+			//return start + ("|").repeat(flr).padEnd(width, ".") + end
+		}
+		return '---'
+	}
+
+	const normalizePct = (val, low = 0, high = 100, limit = false) => {
+		if (limit) {
+			val = (val < low) ? low : val
+			val = (val > high) ? high : val
+		}
+		return (val < low || val > high) ? null : (((val - low) / (high - low)) * 100).toFixed(2)
+	}
 
 	self.setVariableValues({
 		series: self.data.series,
@@ -109,9 +129,13 @@ export function checkVariables(self) {
 		tSpeedVar: self.tSpeed,
 		zSpeedVar: self.zSpeed,
 		fSpeedVar: self.fSpeed,
-		zoomPosition: ((self.data.zoomPosition - 0x555) / 27.30).toPrecision(3) + '%',
-		focusPosition: ((self.data.focusPosition - 0x555) / 27.30).toPrecision(3) + '%',
-		irisPosition: ((self.data.irisPosition - 0x555) / 27.30).toPrecision(3) + '%',
+		zoomPosition: normalizePct(self.data.zoomPosition, 0x555, 0xFFF),
+		focusPosition: normalizePct(self.data.focusPosition, 0x555, 0xFFF),
+		irisPosition: normalizePct(self.data.irisPosition, 0x555, 0xFFF),
+		zoomPositionBar: progressBar(normalizePct(self.data.zoomPosition, 0x555, 0xFFF), 14, 'W', 'T'),
+		focusPositionBar: progressBar(normalizePct(self.data.focusPosition, 0x555, 0xFFF), 14, 'N', 'F'),
+		irisPositionBar: progressBar(normalizePct(self.data.irisPosition, 0x555, 0xFFF), 14, 'C', 'O'),
+		irisF: 'F'+(self.data.irisF / 10).toFixed(1),
 		lastPresetCompleted: (self.data.lastPresetCompleted + 1).toString(),
 	})
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -1,5 +1,4 @@
 import { getAndUpdateSeries } from './common.js'
-import { CHOICE_WB_GET } from './choices.js'
 
 // ##########################
 // #### Define Variables ####
@@ -31,7 +30,7 @@ export function setVariables(self) {
 		variables.push({ variableId: 'power', name: 'Power ON/OFF' })
 	}
 	if (SERIES.variables.colorbar) {
-		variables.push({ variableId: 'colorbar', name: 'Color Bar ENABLED' })
+		variables.push({ variableId: 'colorbar', name: 'Color Bar ON/OFF' })
 	}
 	if (SERIES.variables.tally) {
 		variables.push({ variableId: 'tally', name: 'Red Tally ON/OFF' })
@@ -63,6 +62,9 @@ export function setVariables(self) {
 	variables.push({ variableId: 'tSpeedVar', name: 'Tilt Speed' })
 	variables.push({ variableId: 'zSpeedVar', name: 'Zoom Speed' })
 	variables.push({ variableId: 'fSpeedVar', name: 'Focus Speed' })
+	variables.push({ variableId: 'zoomPosition', name: 'Zoom Position' })
+	variables.push({ variableId: 'focusPosition', name: 'Focus Position' })
+	variables.push({ variableId: 'irisPosition', name: 'Iris Position' })
 	return variables
 }
 
@@ -81,7 +83,7 @@ export function checkVariables(self) {
 		: null
 
 	const whiteBalance = SERIES.actions.whiteBalance
-		? CHOICE_WB_GET.find((whiteBalance) => whiteBalance.id == self.data.whiteBalance)
+		? SERIES.actions.whiteBalance.dropdown.find((whiteBalance) => whiteBalance.id == self.data.whiteBalance)
 		: null
 
 
@@ -107,6 +109,9 @@ export function checkVariables(self) {
 		tSpeedVar: self.tSpeed,
 		zSpeedVar: self.zSpeed,
 		fSpeedVar: self.fSpeed,
-		lastPresetCompleted: self.data.lastPresetCompleted,
+		zoomPosition: ((self.data.zoomPosition - 0x555) / 27.30).toPrecision(3) + '%',
+		focusPosition: ((self.data.focusPosition - 0x555) / 27.30).toPrecision(3) + '%',
+		irisPosition: ((self.data.irisPosition - 0x555) / 27.30).toPrecision(3) + '%',
+		lastPresetCompleted: (self.data.lastPresetCompleted + 1).toString(),
 	})
 }


### PR DESCRIPTION
This PR mainly improves the support for cameras without reverse TCP status update channel like the CX350 series.
Additionally it fixes some minor bugs, typos and descriptions and finally removes legacy tally info from config page.

The support for all models is done by switching the name detection from `camdata.html` to an additional `getinfo` call on initialisation which should be supported by all models including the non-PTZ cameras.

It also fixes the preset generator to stop generate presets for unsupported actions found during testing.

And by the way it adds control for Color Bar (fixes #77), fixes manual/auto iris control (fixes #61) and adds preset completion notification (partly fixes #36).