### PR TITLE
Support for OPT Switch command for AW-HE40 (and AW-HE38) 

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -818,6 +818,7 @@ export function getActionDefinitions(self) {
 			},
 		}
 	}
+
 	// ##########################
 	// #### Exposure Actions ####
 	// ##########################

--- a/src/actions.js
+++ b/src/actions.js
@@ -818,23 +818,6 @@ export function getActionDefinitions(self) {
 			},
 		}
 	}
-        if (seriesActions.opt) {
-		actions.optOff = {
-			name: 'OPT - Turn Off',
-			options: [],
-			callback: async (action) => {
-				await sendPTZ(self, 'D60')
-			},
-		}
-
-		actions.optOn = {
-			name: 'OPT - Turn On',
-			options: [],
-			callback: async (action) => {
-				await sendPTZ(self, 'D61')
-			},
-		}
-	}
 	// ##########################
 	// #### Exposure Actions ####
 	// ##########################

--- a/src/actions.js
+++ b/src/actions.js
@@ -818,7 +818,23 @@ export function getActionDefinitions(self) {
 			},
 		}
 	}
+        if (seriesActions.opt) {
+		actions.optOff = {
+			name: 'OPT - Turn Off',
+			options: [],
+			callback: async (action) => {
+				await sendPTZ(self, 'D60')
+			},
+		}
 
+		actions.optOn = {
+			name: 'OPT - Turn On',
+			options: [],
+			callback: async (action) => {
+				await sendPTZ(self, 'D61')
+			},
+		}
+	}
 	// ##########################
 	// #### Exposure Actions ####
 	// ##########################

--- a/src/models.js
+++ b/src/models.js
@@ -136,7 +136,7 @@ export const SERIES_SPECS = [
 			gainValue: true,
 			preset: true,
 			colorTemperature: false,
-			opt: true,
+			night: true,
 		},
 		feedbacks: {
 			powerState: true,
@@ -150,7 +150,7 @@ export const SERIES_SPECS = [
 			colorBarsTypeState: true,
 			colorBarsTitleState: true,
 			colorBarsToneState: false,
-			optState: true,
+			nightState: true,
 		},
 		actions: {
 			panTilt: true,
@@ -179,7 +179,7 @@ export const SERIES_SPECS = [
 			colorBarsType: true,
 			colorBarsTitle: true,
 			colorBarsTone: false,
-			opt: true,
+			night: true,
 		},
 	},
 

--- a/src/models.js
+++ b/src/models.js
@@ -136,6 +136,7 @@ export const SERIES_SPECS = [
 			gainValue: true,
 			preset: true,
 			colorTemperature: false,
+			opt: true,
 		},
 		feedbacks: {
 			powerState: true,
@@ -149,6 +150,7 @@ export const SERIES_SPECS = [
 			colorBarsTypeState: true,
 			colorBarsTitleState: true,
 			colorBarsToneState: false,
+			optState: true,
 		},
 		actions: {
 			panTilt: true,
@@ -177,6 +179,7 @@ export const SERIES_SPECS = [
 			colorBarsType: true,
 			colorBarsTitle: true,
 			colorBarsTone: false,
+			opt: true,
 		},
 	},
 


### PR DESCRIPTION
The OPT switch is used to turn an IR Cut filter on and off within the camera by physically moving it in front of the sensor. In normal state this prevents IR light from hitting the sensor and allows for normal colour video, when this is turned off it allows for IR illumination such as IR spotlights and floodlights, and the picture turns to black and white.

I am not a good programmer but I have done my best to implement this into this pull request! 