### PR TITLE
Add support for AW-HE145

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -18,6 +18,7 @@ export const MODELS = [
 	{ id: 'AW-HE120', series: 'AW-HE120', label: 'AW-HE120' },
 	{ id: 'AW-HE130', series: 'AW-HE130', label: 'AW-HE130' },
 	{ id: 'AW-HR140', series: 'AW-HR140', label: 'AW-HR140' },
+	{ id: 'AW-HE145', series: 'UE150', label: 'AW-HE145' },
 	{ id: 'AW-HN38', series: 'HE40', label: 'AW-HN38' },
 	{ id: 'AW-HN40', series: 'HE40', label: 'AW-HN40' },
 	{ id: 'AW-HN65', series: 'HE40', label: 'AW-HN65' },


### PR DESCRIPTION
The feature set of the AW-HE145 seems to be compatible with UE150 series, according to bitfocus/companion-module-panasonic-cameras